### PR TITLE
Test Phar build steps against WP-CLI `vendor-dir` branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
   - phpenv config-rm xdebug.ini
 
 install:
-  - composer require wp-cli/wp-cli:dev-master
+  - composer require wp-cli/wp-cli:dev-vendor-dir
   - composer install
   - bash bin/install-package-tests.sh
 


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/pull/4016

This pull request doesn't need to be merged; only used for testing.