### PR TITLE
Fix path returned from get_composer_json_path under Windows

### DIFF
--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -758,7 +758,13 @@ class Package_Command extends WP_CLI_Command {
 			if ( getenv( 'WP_CLI_PACKAGES_DIR' ) ) {
 				$composer_path = rtrim( getenv( 'WP_CLI_PACKAGES_DIR' ), '/' ) . '/composer.json';
 			} else {
-				$composer_path = getenv( 'HOME' ) . '/.wp-cli/packages/composer.json';
+				$home = getenv( 'HOME' );
+				if ( ! $home ) {
+					// In Windows $HOME may not be defined
+					$home = getenv( 'HOMEDRIVE' ) . getenv( 'HOMEPATH' );
+				}
+
+				$composer_path = rtrim( $home, '/\\' ) . '/.wp-cli/packages/composer.json';
 			}
 
 			// `composer.json` and its directory might need to be created


### PR DESCRIPTION
On Windows operating systems the `$HOME` environment variable may not be defined leading to this package attempting to create the composer package directory under `/.wp-cli/packages/composer.json` which fails:

```
$ wp package list
Error: Composer directory for packages couldn't be created.
```

This fix will attempt to create the home path from `$HOMEDRIVE` and `$HOMEPATH` environment variables if `$HOME` is empty.