### PR TITLE
Directly target `wp-cli/wp-cli:dev-master` to avoid loading an old version of `mustangostang/spyc`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         ]
     },
     "require": {
-        "wp-cli/wp-cli": "*",
+        "wp-cli/wp-cli": "dev-master",
         "composer/composer": "^1.2.0"
     },
     "require-dev": {


### PR DESCRIPTION
This can be reverted as soon as 1.2.0 is released.

Fixes https://github.com/wp-cli/wp-cli/issues/4098