### PR TITLE
Update test to reflect new error string when no WP install is found

### DIFF
--- a/features/package.feature
+++ b/features/package.feature
@@ -22,7 +22,7 @@ Feature: Manage WP-CLI packages
       """
     And STDERR should contain:
       """
-      Error: This does not seem to be a WordPress install.
+      Warning: No WordPress install found.
       """
 
     When I run `wp package list`


### PR DESCRIPTION
Introduced by https://github.com/wp-cli/wp-cli/pull/4303
Failing build is https://travis-ci.org/wp-cli/automated-tests/jobs/266041334