### PR TITLE
GH#4232 Added check for package name

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -122,14 +122,14 @@ Feature: Install WP-CLI packages
 
   @github-api
   Scenario: Install a package from a Git URL
-    When I run `wp package install git@github.com:sidsector9/ee-command.git`
+    When I run `wp package install git@github.com:wp-cli-test/repository-name.git`
     And STDOUT should contain:
       """
       Package name mismatch...Updating the name with correct value.
       """
     And the {PACKAGE_PATH}composer.json file should contain:
       """
-      "this/that": "dev-master"
+      "wp-cli-test/package-name": "dev-master"
       """
     Given an empty directory
 

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -122,6 +122,15 @@ Feature: Install WP-CLI packages
 
   @github-api
   Scenario: Install a package from a Git URL
+    When I run `wp package install git@github.com:sidsector9/ee-command.git`
+    And STDOUT should contain:
+      """
+      Package name mismatch...Updating the name with correct value.
+      """
+    And the {PACKAGE_PATH}composer.json file should contain:
+      """
+      "this/that": "dev-master"
+      """
     Given an empty directory
 
     When I try `wp package install git@github.com:wp-cli.git`

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -203,7 +203,7 @@ class Package_Command extends WP_CLI_Command {
 			if ( ! empty( $matches[1] ) ) {
 				$package_name = $matches[1];
 				$raw_content_url = 'https://raw.githubusercontent.com/' . $package_name . '/master/composer.json';
-				$composer_content_as_array = json_decode( $this->get_data_from_url( $raw_content_url ), true );
+				$composer_content_as_array = json_decode( WP_CLI\Utils\http_request( 'GET', $raw_content_url )->body, true );
 				$package_name_on_repo = $composer_content_as_array['name'];
 				if ( $package_name !== $package_name_on_repo ) {
 					WP_CLI::error( 'Package names mismatch.' );
@@ -909,32 +909,5 @@ class Package_Command extends WP_CLI_Command {
 	 */
 	private function is_git_repository( $package ) {
 		return '.git' === strtolower( substr( $package, -4, 4 ) );
-	}
-
-	/**
-	 * Gets data of a page using URL.
-	 *
-	 * @param  string $url URL of the Git repository.
-	 * @return string
-	 */
-	private function get_data_from_url( $url ) {
-		if ( function_exists( 'curl_exec' ) ) {
-			if ( ! function_exists( 'curl_init' ) ) {
-				WP_CLI::error( 'CURL is not installed.' );
-			}
-			$curl = curl_init();
-			curl_setopt( $curl, CURLOPT_URL, $url );
-			curl_setopt( $curl, CURLOPT_RETURNTRANSFER, true );
-			$data_as_string = curl_exec( $curl );
-			curl_close( $curl );
-		} elseif ( function_exists( 'file_get_contents' ) ) {
-			$data_as_string = file_get_contents( $url );
-		} elseif ( function_exists( 'fopen' ) && function_exists( 'stream_get_contents' ) ) {
-			$handle = fopen( $url, 'r' );
-			$data_as_string = stream_get_contents( $handle );
-		} else {
-			$data_as_string = false;
-		}
-		return $data_as_string;
 	}
 }

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -214,10 +214,8 @@ class Package_Command extends WP_CLI_Command {
 
 				// If package name and repository name are not identical, then fix it.
 				if ( $package_name !== $package_name_on_repo ) {
-					$set_package_name = $package_name_on_repo;
+					$package_name = $package_name_on_repo;
 					WP_CLI::warning( 'Package name mismatch...Updating the name with correct value.' );
-				} else {
-					$set_package_name = $package_name;
 				}
 			} else {
 				WP_CLI::error( "Couldn't parse package name from expected path '<name>/<package>'." );
@@ -281,12 +279,12 @@ class Package_Command extends WP_CLI_Command {
 		$json_manipulator = new JsonManipulator( $composer_backup );
 		$json_manipulator->addMainKey( 'name', 'wp-cli/wp-cli' );
 		$json_manipulator->addMainKey( 'version', self::get_wp_cli_version_composer() );
-		$json_manipulator->addLink( 'require', $set_package_name, $version );
+		$json_manipulator->addLink( 'require', $package_name, $version );
 		$json_manipulator->addConfigSetting( 'secure-http', true );
 
 		if ( $git_package ) {
 			WP_CLI::log( sprintf( 'Registering %s as a VCS repository...', $git_package ) );
-			$json_manipulator->addRepository( $set_package_name, array( 'type' => 'vcs', 'url' => $git_package ) );
+			$json_manipulator->addRepository( $package_name, array( 'type' => 'vcs', 'url' => $git_package ) );
 		} else if ( $dir_package ) {
 			WP_CLI::log( sprintf( 'Registering %s as a path repository...', $dir_package ) );
 			$json_manipulator->addRepository( $package_name, array( 'type' => 'path', 'url' => $dir_package ) );

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -202,11 +202,22 @@ class Package_Command extends WP_CLI_Command {
 			preg_match( '#([^:\/]+\/[^\/]+)\.git#', $package_name, $matches );
 			if ( ! empty( $matches[1] ) ) {
 				$package_name = $matches[1];
+
+				// Generate raw git URL of composer.json file.
 				$raw_content_url = 'https://raw.githubusercontent.com/' . $package_name . '/master/composer.json';
+
+				// Convert composer.json JSON to Array.
 				$composer_content_as_array = json_decode( WP_CLI\Utils\http_request( 'GET', $raw_content_url )->body, true );
+
+				// Package name in composer.json that is hosted on GitHub.
 				$package_name_on_repo = $composer_content_as_array['name'];
+
+				// If package name and repository name are not identical, then fix it.
 				if ( $package_name !== $package_name_on_repo ) {
-					WP_CLI::error( 'Package names mismatch.' );
+					$set_package_name = $package_name_on_repo;
+					WP_CLI::warning( 'Package name mismatch...Updating the name with correct value.' );
+				} else {
+					$set_package_name = $package_name;
 				}
 			} else {
 				WP_CLI::error( "Couldn't parse package name from expected path '<name>/<package>'." );
@@ -270,17 +281,16 @@ class Package_Command extends WP_CLI_Command {
 		$json_manipulator = new JsonManipulator( $composer_backup );
 		$json_manipulator->addMainKey( 'name', 'wp-cli/wp-cli' );
 		$json_manipulator->addMainKey( 'version', self::get_wp_cli_version_composer() );
-		$json_manipulator->addLink( 'require', $package_name, $version );
+		$json_manipulator->addLink( 'require', $set_package_name, $version );
 		$json_manipulator->addConfigSetting( 'secure-http', true );
 
 		if ( $git_package ) {
 			WP_CLI::log( sprintf( 'Registering %s as a VCS repository...', $git_package ) );
-			$json_manipulator->addRepository( $package_name, array( 'type' => 'vcs', 'url' => $git_package ) );
+			$json_manipulator->addRepository( $set_package_name, array( 'type' => 'vcs', 'url' => $git_package ) );
 		} else if ( $dir_package ) {
 			WP_CLI::log( sprintf( 'Registering %s as a path repository...', $dir_package ) );
 			$json_manipulator->addRepository( $package_name, array( 'type' => 'path', 'url' => $dir_package ) );
 		}
-
 		$composer_backup_decoded = json_decode( $composer_backup, true );
 		// If the composer file does not contain the current package index repository, refresh the repository definition.
 		if ( empty( $composer_backup_decoded['repositories']['wp-cli']['url'] ) || self::PACKAGE_INDEX_URL != $composer_backup_decoded['repositories']['wp-cli']['url'] ) {
@@ -298,7 +308,6 @@ class Package_Command extends WP_CLI_Command {
 		// Set up the EventSubscriber
 		$event_subscriber = new \WP_CLI\PackageManagerEventSubscriber;
 		$composer->getEventDispatcher()->addSubscriber( $event_subscriber );
-
 		// Set up the installer
 		$install = Installer::create( new ComposerIO, $composer );
 		$install->setUpdate( true ); // Installer class will only override composer.lock with this flag


### PR DESCRIPTION
As of now, only packages hosted on GitHub is supported.

Related to issue [4232](https://github.com/wp-cli/wp-cli/issues/4232)