### PR TITLE
STDOUT -> STDERR in name mismatch package-install test.

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -123,7 +123,7 @@ Feature: Install WP-CLI packages
   @github-api
   Scenario: Install a package from a Git URL
     When I run `wp package install git@github.com:wp-cli-test/repository-name.git`
-    And STDOUT should contain:
+    And STDERR should contain:
       """
       Package name mismatch...Updating the name with correct value.
       """


### PR DESCRIPTION
See https://github.com/wp-cli/package-command/issues/44#issuecomment-340532865

Trivial fix to check `STDERR` instead of `STDOUT` in `features/package-install.feature` for "Package name mismatch" warning.

Not showing in Travis as `@github-api` tagged tests aren't run there (yet!).