### PR TITLE
Add GITHUB_TOKEN and COMPOSER_AUTH handling.

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -122,16 +122,22 @@ Feature: Install WP-CLI packages
 
   @github-api
   Scenario: Install a package from a Git URL
-    When I run `wp package install git@github.com:wp-cli-test/repository-name.git`
+    Given an empty directory
+
+    When I try `wp package install git@github.com:wp-cli-test/repository-name.git`
+    Then the return code should be 0
     And STDERR should contain:
       """
-      Package name mismatch...Updating the name with correct value.
+      Warning: Package name mismatch...Updating the name with correct value.
+      """
+    And STDOUT should contain:
+      """
+      Success: Package installed.
       """
     And the {PACKAGE_PATH}composer.json file should contain:
       """
       "wp-cli-test/package-name": "dev-master"
       """
-    Given an empty directory
 
     When I try `wp package install git@github.com:wp-cli.git`
     Then STDERR should be:
@@ -197,7 +203,7 @@ Feature: Install WP-CLI packages
       """
       Installing package schlessera/test-command (dev-master)
       Updating {PACKAGE_PATH}composer.json to require the package...
-      Registering git@github.com:schlessera/test-command.git as a VCS repository...
+      Registering https://github.com/schlessera/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
     And STDOUT should contain:
@@ -241,7 +247,7 @@ Feature: Install WP-CLI packages
       """
       Installing package schlessera/test-command (^0)
       Updating {PACKAGE_PATH}composer.json to require the package...
-      Registering git@github.com:schlessera/test-command.git as a VCS repository...
+      Registering https://github.com/schlessera/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
     And STDOUT should contain:
@@ -285,7 +291,7 @@ Feature: Install WP-CLI packages
       """
       Installing package schlessera/test-command (0.1.0)
       Updating {PACKAGE_PATH}composer.json to require the package...
-      Registering git@github.com:schlessera/test-command.git as a VCS repository...
+      Registering https://github.com/schlessera/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
     And STDOUT should contain:
@@ -329,7 +335,7 @@ Feature: Install WP-CLI packages
       """
       Installing package schlessera/test-command (dev-master#8e99bba16a65a3cde7405178a6badbb49349f554)
       Updating {PACKAGE_PATH}composer.json to require the package...
-      Registering git@github.com:schlessera/test-command.git as a VCS repository...
+      Registering https://github.com/schlessera/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
     And STDOUT should contain:
@@ -373,7 +379,7 @@ Feature: Install WP-CLI packages
       """
       Installing package schlessera/test-command (dev-custom-branch)
       Updating {PACKAGE_PATH}composer.json to require the package...
-      Registering git@github.com:schlessera/test-command.git as a VCS repository...
+      Registering https://github.com/schlessera/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
     And STDOUT should contain:

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -194,7 +194,8 @@ Feature: Install WP-CLI packages
       wp-cli/google-sitemap-generator-cli
       """
 
-  @github-api @shortened
+  # Current releases of schlessera/test-command are PHP 5.5 dependent.
+  @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier
     Given an empty directory
 
@@ -238,7 +239,8 @@ Feature: Install WP-CLI packages
       schlessera/test-command
       """
 
-  @github-api @shortened
+  # Current releases of schlessera/test-command are PHP 5.5 dependent.
+  @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier with a version requirement
     Given an empty directory
 
@@ -282,7 +284,8 @@ Feature: Install WP-CLI packages
       schlessera/test-command
       """
 
-  @github-api @shortened
+  # Current releases of schlessera/test-command are PHP 5.5 dependent.
+  @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier with a specific version
     Given an empty directory
 
@@ -326,7 +329,8 @@ Feature: Install WP-CLI packages
       schlessera/test-command
       """
 
-  @github-api @shortened
+  # Current releases of schlessera/test-command are PHP 5.5 dependent.
+  @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier and a specific commit hash
     Given an empty directory
 
@@ -370,7 +374,8 @@ Feature: Install WP-CLI packages
       schlessera/test-command
       """
 
-  @github-api @shortened
+  # Current releases of schlessera/test-command are PHP 5.5 dependent.
+  @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier and a branch
     Given an empty directory
 

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -202,9 +202,9 @@ class Package_Command extends WP_CLI_Command {
 	 *     $ wp package install google-sitemap-generator-cli.zip
 	 */
 	public function install( $args, $assoc_args ) {
-		$this->set_composer_auth_env_var();
 		list( $package_name ) = $args;
 
+		$this->set_composer_auth_env_var();
 		$git_package = $dir_package = false;
 		$version = 'dev-master';
 		if ( $this->is_git_repository( $package_name ) ) {
@@ -318,7 +318,6 @@ class Package_Command extends WP_CLI_Command {
 		// Set up the EventSubscriber
 		$event_subscriber = new \WP_CLI\PackageManagerEventSubscriber;
 		$composer->getEventDispatcher()->addSubscriber( $event_subscriber );
-
 		// Set up the installer
 		$install = Installer::create( new ComposerIO, $composer );
 		$install->setUpdate( true ); // Installer class will only override composer.lock with this flag
@@ -494,9 +493,9 @@ class Package_Command extends WP_CLI_Command {
 	 *     Success: Uninstalled package.
 	 */
 	public function uninstall( $args ) {
-		$this->set_composer_auth_env_var();
 		list( $package_name ) = $args;
 
+		$this->set_composer_auth_env_var();
 		try {
 			$composer = $this->get_composer();
 		} catch( Exception $e ) {

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -137,6 +137,7 @@ class Package_Command extends WP_CLI_Command {
 	 *       version: dev-master
 	 */
 	public function browse( $_, $assoc_args ) {
+		$this->set_composer_auth_env_var();
 		if ( empty( $assoc_args['format'] ) || 'table' === $assoc_args['format'] ) {
 			WP_CLI::line( WP_CLI::colorize( '%CAlthough the package index will remain in place for backward compatibility reasons, it has been deprecated and will not be updated further. Please refer to https://github.com/wp-cli/ideas/issues/51 to read about its potential replacement.%n' ) );
 		}
@@ -201,6 +202,7 @@ class Package_Command extends WP_CLI_Command {
 	 *     $ wp package install google-sitemap-generator-cli.zip
 	 */
 	public function install( $args, $assoc_args ) {
+		$this->set_composer_auth_env_var();
 		list( $package_name ) = $args;
 
 		$git_package = $dir_package = false;
@@ -213,9 +215,11 @@ class Package_Command extends WP_CLI_Command {
 
 				// Generate raw git URL of composer.json file.
 				$raw_content_url = 'https://raw.githubusercontent.com/' . $package_name . '/master/composer.json';
+				$github_token = getenv( 'GITHUB_TOKEN' ); // Use GITHUB_TOKEN if available to avoid authorization failures or rate-limiting.
+				$headers = $github_token ? array( 'Authorization' => 'token ' . $github_token ) : array();
 
 				// Convert composer.json JSON to Array.
-				$composer_content_as_array = json_decode( WP_CLI\Utils\http_request( 'GET', $raw_content_url )->body, true );
+				$composer_content_as_array = json_decode( WP_CLI\Utils\http_request( 'GET', $raw_content_url, null /*data*/, $headers )->body, true );
 
 				// Package name in composer.json that is hosted on GitHub.
 				$package_name_on_repo = $composer_content_as_array['name'];
@@ -314,6 +318,7 @@ class Package_Command extends WP_CLI_Command {
 		// Set up the EventSubscriber
 		$event_subscriber = new \WP_CLI\PackageManagerEventSubscriber;
 		$composer->getEventDispatcher()->addSubscriber( $event_subscriber );
+
 		// Set up the installer
 		$install = Installer::create( new ComposerIO, $composer );
 		$install->setUpdate( true ); // Installer class will only override composer.lock with this flag
@@ -385,6 +390,7 @@ class Package_Command extends WP_CLI_Command {
 	 * @subcommand list
 	 */
 	public function list_( $args, $assoc_args ) {
+		$this->set_composer_auth_env_var();
 		$this->show_packages( 'list', $this->get_installed_packages(), $assoc_args );
 	}
 
@@ -439,6 +445,7 @@ class Package_Command extends WP_CLI_Command {
 	 *     Success: Packages updated.
 	 */
 	public function update() {
+		$this->set_composer_auth_env_var();
 		try {
 			$composer = $this->get_composer();
 		} catch( Exception $e ) {
@@ -487,6 +494,7 @@ class Package_Command extends WP_CLI_Command {
 	 *     Success: Uninstalled package.
 	 */
 	public function uninstall( $args ) {
+		$this->set_composer_auth_env_var();
 		list( $package_name ) = $args;
 
 		try {
@@ -707,9 +715,12 @@ class Package_Command extends WP_CLI_Command {
 		}
 
 		// Fall back to GitHub URL if we had no match in the package index.
-		$response = Utils\http_request( 'GET', "https://github.com/{$package_name}.git" );
+		$url = "https://github.com/{$package_name}.git";
+		$github_token = getenv( 'GITHUB_TOKEN' ); // Use GITHUB_TOKEN if available to avoid authorization failures or rate-limiting.
+		$headers = $github_token ? array( 'Authorization' => 'token ' . $github_token ) : array();
+		$response = Utils\http_request( 'GET', $url, null /*data*/, $headers );
 		if ( 20 === (int) substr( $response->status_code, 0, 2 ) ) {
-			return "git@github.com:{$package_name}.git";
+			return $url;
 		}
 
 		return false;
@@ -934,5 +945,25 @@ class Package_Command extends WP_CLI_Command {
 	 */
 	private function is_git_repository( $package ) {
 		return '.git' === strtolower( substr( $package, -4, 4 ) );
+	}
+
+	/**
+	 * Set `COMPOSER_AUTH` environment variable (which Composer merges into the config setup in `Composer\Factory::createConfig()`) depending on available environment variables.
+	 * Avoids authorization failures when accessing various sites.
+	 */
+	private function set_composer_auth_env_var() {
+		$changed = false;
+		$composer_auth = getenv( 'COMPOSER_AUTH' );
+		if ( ! $composer_auth || ! ( $composer_auth = json_decode( $composer_auth, true /*assoc*/ ) ) || ! is_array( $composer_auth ) ) {
+			$composer_auth = array();
+		}
+		// TODO: bitbucket-oauth, gitlab-oauth, gitlab-token and http-basic.
+		if ( ! isset( $composer_auth['github-oauth'] ) && ( $github_token = getenv( 'GITHUB_TOKEN' ) ) ) {
+			$composer_auth['github-oauth'] = array( 'github.com' => $github_token );
+			$changed = true;
+		}
+		if ( $changed ) {
+			putenv( 'COMPOSER_AUTH=' . json_encode( $composer_auth ) );
+		}
 	}
 }

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -956,7 +956,6 @@ class Package_Command extends WP_CLI_Command {
 		if ( ! $composer_auth || ! ( $composer_auth = json_decode( $composer_auth, true /*assoc*/ ) ) || ! is_array( $composer_auth ) ) {
 			$composer_auth = array();
 		}
-		// TODO: bitbucket-oauth, gitlab-oauth, gitlab-token and http-basic.
 		if ( ! isset( $composer_auth['github-oauth'] ) && ( $github_token = getenv( 'GITHUB_TOKEN' ) ) ) {
 			$composer_auth['github-oauth'] = array( 'github.com' => $github_token );
 			$changed = true;

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -45,7 +45,9 @@ $skip_tags = array_merge(
 );
 
 # Skip Github API tests by default because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612
-$skip_tags[] = '@github-api';
+if ( ! getenv( 'GITHUB_TOKEN' ) ) {
+	$skip_tags[] = '@github-api';
+}
 
 # Skip tests known to be broken.
 $skip_tags[] = '@broken';

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -44,7 +44,7 @@ $skip_tags = array_merge(
 	version_tags( 'less-than-php', PHP_VERSION, '>' )
 );
 
-# Skip Github API tests by default because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612
+# Skip Github API tests if `GITHUB_TOKEN` not available because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612
 if ( ! getenv( 'GITHUB_TOKEN' ) ) {
 	$skip_tags[] = '@github-api';
 }


### PR DESCRIPTION
Related https://github.com/wp-cli/package-command/issues/44#issuecomment-340582417

Adds a `Package_Command::set_composer_auth_env_var()` function to set the `COMPOSER_AUTH` environment var used by Composer with the value of `GITHUB_TOKEN` if available, to avoid authorization failures, and calls it before each command. (There are undoubtedly other ways to achieve this, so other ideas might be better.)

Also adds `GITHUB_TOKEN` authorization to the http requests à la https://github.com/wp-cli/wp-cli/pull/4281.

Also only sets the `@github-api` tag in `utils/behat-tags.php` if `GITHUB_TOKEN` not available - this is only temporary as will also do the same in the source of truth version `wp-cli/wp-cli` shortly with a PR there enabling `@github-api` tests on Travis.

Note I temporarily added my own GITHUB_TOKEN to https://travis-ci.org/wp-cli/package-command/settings to get the tests to run, but it would probably be best if one of the maintainers added it instead.

Also changes `get_package_by_shortened_identifier()` to return the `https` url rather than the ssh `git@` version, as this is actually what is tested and seems to be the recommended protocol nowadays anyway ([Which remote URL should I use?](https://help.github.com/articles/which-remote-url-should-i-use/)), and adapts the output checks in tests accordingly.

Also tags the tests involving `schlessera/test-command` as `@require-php-5.5`, as it's currently PHP 5.5.0 dependent - see https://github.com/schlessera/test-command/pull/1

Also clarifies the mismatch test a bit.