### PR TITLE
Use pretty name in list to cater for mixed-case names; add as optional field.

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -194,6 +194,54 @@ Feature: Install WP-CLI packages
       wp-cli/google-sitemap-generator-cli
       """
 
+  @github-api
+  Scenario: Install a package from a Git URL with mixed case git name but lower case composer.json name
+    Given an empty directory
+
+    When I try `wp package install https://github.com/CapitalWPCLI/examplecommand.git`
+    Then the return code should be 0
+    And STDERR should contain:
+      """
+      Warning: Package name mismatch...Updating the name with correct value.
+      """
+    And STDOUT should contain:
+      """
+      Success: Package installed.
+      """
+
+    When I run `wp package list --fields=name,pretty_name`
+    Then STDOUT should be a table containing rows:
+      | name                        | pretty_name                 |
+      | capitalwpcli/examplecommand | capitalwpcli/examplecommand |
+
+    When I run `wp hello-world`
+    Then STDOUT should contain:
+      """
+      Success: Hello world.
+      """
+
+  @github-api
+  Scenario: Install a package from a Git URL with mixed case git name and the same mixed case composer.json name
+    Given an empty directory
+
+    When I run `wp package install https://github.com/gitlost/TestMixedCaseCommand.git`
+    Then STDERR should be empty
+    And STDOUT should contain:
+      """
+      Success: Package installed.
+      """
+
+    When I run `wp package list --fields=name,pretty_name`
+    Then STDOUT should be a table containing rows:
+      | name                         | pretty_name                  |
+      | gitlost/testmixedcasecommand | gitlost/TestMixedCaseCommand |
+
+    When I run `wp TestMixedCaseCommand`
+    Then STDOUT should contain:
+      """
+      Success: Test Mixed Case Command Name
+      """
+
   # Current releases of schlessera/test-command are PHP 5.5 dependent.
   @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -114,7 +114,9 @@ class Package_Command extends WP_CLI_Command {
 	 * * authors
 	 * * version
 	 *
-	 * There are no optionally available fields.
+	 * These fields are optionally available:
+	 *
+	 * * pretty_name
 	 *
 	 * ## EXAMPLES
 	 *
@@ -376,6 +378,7 @@ class Package_Command extends WP_CLI_Command {
 	 * These fields are optionally available:
 	 *
 	 * * description
+	 * * pretty_name
 	 *
 	 * ## EXAMPLES
 	 *
@@ -681,6 +684,7 @@ class Package_Command extends WP_CLI_Command {
 				}
 				$package_output['update'] = $update;
 				$package_output['update_version'] = $update_version;
+				$package_output['pretty_name'] = $package->getPrettyName();
 				$list[ $package_output['name'] ] = $package_output;
 			}
 		}
@@ -742,7 +746,8 @@ class Package_Command extends WP_CLI_Command {
 		}
 		$installed_packages = array();
 		foreach( $repo->getCanonicalPackages() as $package ) {
-			if ( in_array( $package->getName(), $installed_package_keys, true ) ) {
+			// Use pretty name as it's case sensitive.
+			if ( in_array( $package->getPrettyName(), $installed_package_keys, true ) ) {
 				$installed_packages[] = $package;
 			}
 		}


### PR DESCRIPTION
See https://github.com/wp-cli/package-command/issues/43

Uses `Composer\Package::getPrettyName()` in matching installed package names as it's the same as the actual `composer.json` name, which can be case sensitive (though not usually), and adds it as an optional field `pretty_name` to the `list` and `browse` commands.

Also adds a test for the more usual case of having a lower-case only name in `composer.json` where the git url is mixed-case, as originally reported in https://github.com/wp-cli/package-command/issues/43