### PR TITLE
Convert package subcommand help summaries to use third-person singular verbs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 wp-cli/package-command
 ======================
 
-Manage WP-CLI packages.
+Lists, installs, and removes WP-CLI packages.
 
 [![Build Status](https://travis-ci.org/wp-cli/package-command.svg?branch=master)](https://travis-ci.org/wp-cli/package-command)
 
@@ -11,9 +11,63 @@ Quick links: [Using](#using) | [Installing](#installing) | [Contributing](#contr
 
 This package implements the following commands:
 
+### wp package
+
+Lists, installs, and removes WP-CLI packages.
+
+~~~
+wp package
+~~~
+
+WP-CLI packages are community-maintained projects built on WP-CLI. They can
+contain WP-CLI commands, but they can also just extend WP-CLI in some way.
+
+Installable packages are listed in the
+[Package Index](http://wp-cli.org/package-index/).
+
+Learn how to create your own command from the
+[Commands Cookbook](http://wp-cli.org/docs/commands-cookbook/)
+
+**EXAMPLES**
+
+    # List installed packages
+    $ wp package list
+    +-----------------------+------------------------------------------+---------+------------+
+    | name                  | description                              | authors | version    |
+    +-----------------------+------------------------------------------+---------+------------+
+    | wp-cli/server-command | Start a development server for WordPress |         | dev-master |
+    +-----------------------+------------------------------------------+---------+------------+
+
+    # Install the latest development version of the package
+    $ wp package install wp-cli/server-command
+    Installing package wp-cli/server-command (dev-master)
+    Updating /home/person/.wp-cli/packages/composer.json to require the package...
+    Using Composer to install the package...
+    ---
+    Loading composer repositories with package information
+    Updating dependencies
+    Resolving dependencies through SAT
+    Dependency resolution completed in 0.005 seconds
+    Analyzed 732 packages to resolve dependencies
+    Analyzed 1034 rules to resolve dependencies
+     - Installing package
+    Writing lock file
+    Generating autoload files
+    ---
+    Success: Package installed.
+
+    # Uninstall package
+    $ wp package uninstall wp-cli/server-command
+    Removing require statement from /home/person/.wp-cli/packages/composer.json
+    Deleting package directory /home/person/.wp-cli/packages/vendor/wp-cli/server-command
+    Regenerating Composer autoload.
+    Success: Uninstalled package.
+
+
+
 ### wp package browse
 
-Browse WP-CLI packages available for installation.
+Browses WP-CLI packages available for installation.
 
 ~~~
 wp package browse [--fields=<fields>] [--format=<format>]
@@ -76,7 +130,7 @@ There are no optionally available fields.
 
 ### wp package install
 
-Install a WP-CLI package.
+Installs a WP-CLI package.
 
 ~~~
 wp package install <name|git|path|zip>
@@ -140,7 +194,7 @@ When installing a .zip file, WP-CLI extracts the package to
 
 ### wp package list
 
-List installed WP-CLI packages.
+Lists installed WP-CLI packages.
 
 ~~~
 wp package list [--fields=<fields>] [--format=<format>]
@@ -190,7 +244,7 @@ These fields are optionally available:
 
 ### wp package update
 
-Update all installed WP-CLI packages to their latest version.
+Updates all installed WP-CLI packages to their latest version.
 
 ~~~
 wp package update 
@@ -216,7 +270,7 @@ wp package update
 
 ### wp package uninstall
 
-Uninstall a WP-CLI package.
+Uninstalls a WP-CLI package.
 
 ~~~
 wp package uninstall <name>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wp-cli/package-command",
-    "description": "Manage WP-CLI packages.",
+    "description": "Lists, installs, and removes WP-CLI packages.",
     "type": "wp-cli-package",
     "homepage": "https://github.com/wp-cli/package-command",
     "support": {
@@ -36,6 +36,7 @@
             "dev-master": "1.x-dev"
         },
         "commands": [
+            "package",
             "package browse",
             "package install",
             "package list",

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -81,7 +81,7 @@ class Package_Command extends WP_CLI_Command {
 	private $pool = false;
 
 	/**
-	 * Browse WP-CLI packages available for installation.
+	 * Browses WP-CLI packages available for installation.
 	 *
 	 * Lists packages available for installation from the [Package Index](http://wp-cli.org/package-index/).
 	 * Although the package index will remain in place for backward compatibility reasons, it has been
@@ -145,7 +145,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Install a WP-CLI package.
+	 * Installs a WP-CLI package.
 	 *
 	 * Packages are required to be a valid Composer package, and can be
 	 * specified as:
@@ -349,7 +349,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * List installed WP-CLI packages.
+	 * Lists installed WP-CLI packages.
 	 *
 	 * ## OPTIONS
 	 *
@@ -399,7 +399,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get the path to an installed WP-CLI package, or the package directory.
+	 * Gets the path to an installed WP-CLI package, or the package directory.
 	 *
 	 * If you want to contribute to a package, this is a great way to jump to it.
 	 *
@@ -430,7 +430,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Update all installed WP-CLI packages to their latest version.
+	 * Updates all installed WP-CLI packages to their latest version.
 	 *
 	 * ## EXAMPLES
 	 *
@@ -482,7 +482,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Uninstall a WP-CLI package.
+	 * Uninstalls a WP-CLI package.
 	 *
 	 * ## OPTIONS
 	 *
@@ -555,7 +555,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Check whether a package is a WP-CLI community package based
+	 * Checks whether a package is a WP-CLI community package based
 	 * on membership in our package index.
 	 *
 	 * @param object      $package     A package object
@@ -566,7 +566,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get a Composer instance.
+	 * Gets a Composer instance.
 	 */
 	private function get_composer() {
 		$composer_path = $this->get_composer_json_path();
@@ -583,7 +583,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get all of the community packages.
+	 * Gets all of the community packages.
 	 *
 	 * @return array
 	 */
@@ -602,7 +602,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get the package index instance
+	 * Gets the package index instance
 	 *
 	 * We need to construct the instance manually, because there's no way to select
 	 * a particular instance using $composer->getRepositoryManager()
@@ -633,7 +633,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Display a set of packages
+	 * Displays a set of packages
 	 *
 	 * @param string $context
 	 * @param array
@@ -702,7 +702,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get a package by its shortened identifier.
+	 * Gets a package by its shortened identifier.
 	 *
 	 * A shortened identifier has the form `<vendor>/<package>`.
 	 *
@@ -735,7 +735,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get the installed community packages.
+	 * Gets the installed community packages.
 	 */
 	private function get_installed_packages() {
 		try {
@@ -765,7 +765,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get an installed package by its name.
+	 * Gets an installed package by its name.
 	 */
 	private function get_installed_package_by_name( $package_name ) {
 		foreach( $this->get_installed_packages() as $package ) {
@@ -781,7 +781,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Check if the package name provided is already installed.
+	 * Checks if the package name provided is already installed.
 	 */
 	private function is_package_installed( $package_name ) {
 		if ( $this->get_installed_package_by_name( $package_name ) ) {
@@ -792,7 +792,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get the name of the package from the composer.json in a directory path
+	 * Gets the name of the package from the composer.json in a directory path
 	 *
 	 * @param string $dir_package
 	 * @return array Two-element array containing package name and version.
@@ -818,14 +818,14 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get the composer.json object
+	 * Gets the composer.json object
 	 */
 	private function get_composer_json() {
 		return new JsonFile( $this->get_composer_json_path() );
 	}
 
 	/**
-	 * Get the path to composer.json
+	 * Gets the path to composer.json
 	 */
 	private function get_composer_json_path() {
 		static $composer_path;
@@ -854,7 +854,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get the WP-CLI version for composer.json
+	 * Gets the WP-CLI version for composer.json
 	 */
 	private static function get_wp_cli_version_composer() {
 		preg_match( '#^[0-9\.]+(-(alpha|beta)[^-]{0,})?#', WP_CLI_VERSION, $matches );
@@ -862,7 +862,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Create a default composer.json, should one not already exist
+	 * Creates a default composer.json, should one not already exist
 	 *
 	 * @param string $composer_path Where the composer.json should be created
 	 * @return true|WP_Error
@@ -956,7 +956,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Check whether a given package is a git repository.
+	 * Checks whether a given package is a git repository.
 	 *
 	 * @param string $package Package name to check.
 	 *
@@ -967,7 +967,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Check that `$package_name` matches the name in the repo composer.json, and return corrected value if not.
+	 * Checks that `$package_name` matches the name in the repo composer.json, and return corrected value if not.
 	 */
 	private function check_git_package_name( $package_name ) {
 		// Generate raw git URL of composer.json file.
@@ -1001,7 +1001,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Set `COMPOSER_AUTH` environment variable (which Composer merges into the config setup in `Composer\Factory::createConfig()`) depending on available environment variables.
+	 * Sets `COMPOSER_AUTH` environment variable (which Composer merges into the config setup in `Composer\Factory::createConfig()`) depending on available environment variables.
 	 * Avoids authorization failures when accessing various sites.
 	 */
 	private function set_composer_auth_env_var() {

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -24,7 +24,7 @@ use \WP_CLI\Utils;
 use \WP_CLI\JsonManipulator;
 
 /**
- * Runs WP-CLI package manager commands.
+ * Lists, installs, and removes WP-CLI packages.
  *
  * WP-CLI packages are community-maintained projects built on WP-CLI. They can
  * contain WP-CLI commands, but they can also just extend WP-CLI in some way.


### PR DESCRIPTION
Per wp-cli/wp-cli#4542, this PR converts help docs for package subcommands to use third-person singular verbs.