### PR TITLE
Revert "Add regression test to detect Composer plugin errors"

### DIFF
--- a/features/package.feature
+++ b/features/package.feature
@@ -56,17 +56,3 @@ Feature: Manage WP-CLI packages
 
     When I run `wp --require=bad-command.php package list`
     Then STDERR should be empty
-
-  Scenario: Run package commands without hitting Composer plugin errors in Phar files
-    Given an empty directory
-    And a new Phar with the same version
-
-    When I run `{PHAR_PATH} package list`
-    Then STDERR should not contain:
-      """
-      failed to open stream
-      """
-    And STDERR should not contain:
-      """
-      is not a file in phar
-      """


### PR DESCRIPTION
Reverts wp-cli/package-command#45

I think this should be reverted as it doesn't really test anything and fails if for instance phpunit is added to `require-dev` (which could be something reasonable to do).
  
Edit: actually ignore the point about failing as the other `Phar` steps would fail anyway, unless `make-phar.php` were updated to strip `myclab` (used by phpunit 6). But this test should still be removed I think.