### PR TITLE
Revert composer.json on memory limit error.

### DIFF
--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -87,8 +87,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	private $running_procs = array();
 
 	/**
-	 * Array of variables available as {VARIABLE_NAME}. Some are always set: CORE_CONFIG_SETTINGS, SRC_DIR, CACHE_DIR, WP_VERSION-version-latest. Some are step-dependent:
-	 * RUN_DIR, SUITE_CACHE_DIR, COMPOSER_LOCAL_REPOSITORY, PHAR_PATH. Scenarios can define their own variables using "Given save" steps. Variables are reset for each scenario.
+	 * Array of variables available as {VARIABLE_NAME}. Some are always set: CORE_CONFIG_SETTINGS, SRC_DIR, CACHE_DIR, WP_VERSION-version-latest.
+	 * Some are step-dependent: RUN_DIR, SUITE_CACHE_DIR, COMPOSER_LOCAL_REPOSITORY, PHAR_PATH. One is set on use: INVOKE_WP_CLI_WITH_PHP_ARGS-args.
+	 * Scenarios can define their own variables using "Given save" steps. Variables are reset for each scenario.
 	 */
 	public $variables = array();
 
@@ -117,8 +118,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 		// Ensure we're using the expected `wp` binary
 		$bin_dir = getenv( 'WP_CLI_BIN_DIR' ) ?: realpath( __DIR__ . '/../../bin' );
 		$vendor_dir = realpath( __DIR__ . '/../../vendor/bin' );
+		$path_separator = Utils\is_windows() ? ';' : ':';
 		$env = array(
-			'PATH' =>  $bin_dir . ':' . $vendor_dir . ':' . getenv( 'PATH' ),
+			'PATH' =>  $bin_dir . $path_separator . $vendor_dir . $path_separator . getenv( 'PATH' ),
 			'BEHAT_RUN' => 1,
 			'HOME' => sys_get_temp_dir() . '/wp-cli-home',
 		);
@@ -328,20 +330,55 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	}
 
 	/**
-	 * Replace {VARIABLE_NAME}. Note that variable names can only contain uppercase letters and underscores (no numbers).
+	 * Replace standard {VARIABLE_NAME} variables and the special {INVOKE_WP_CLI_WITH_PHP_ARGS-args} and {WP_VERSION-version-latest} variables.
+	 * Note that standard variable names can only contain uppercase letters, digits and underscores and cannot begin with a digit.
 	 */
 	public function replace_variables( $str ) {
-		$ret = preg_replace_callback( '/\{([A-Z_]+)\}/', array( $this, '_replace_var' ), $str );
-		if ( false !== strpos( $str, '{WP_VERSION-' ) ) {
-			$ret = $this->_replace_wp_versions( $ret );
+		if ( false !== strpos( $str, '{INVOKE_WP_CLI_WITH_PHP_ARGS-' ) ) {
+			$str = $this->replace_invoke_wp_cli_with_php_args( $str );
 		}
-		return $ret;
+		$str = preg_replace_callback( '/\{([A-Z_][A-Z_0-9]*)\}/', array( $this, 'replace_var' ), $str );
+		if ( false !== strpos( $str, '{WP_VERSION-' ) ) {
+			$str = $this->replace_wp_versions( $str );
+		}
+		return $str;
+	}
+
+	/**
+	 * Substitute {INVOKE_WP_CLI_WITH_PHP_ARGS-args} variables.
+	 */
+	private function replace_invoke_wp_cli_with_php_args( $str ) {
+		static $phar_path = null, $shell_path = null;
+
+		if ( null === $phar_path ) {
+			$phar_path = false;
+			if ( ( $bin_dir = getenv( 'WP_CLI_BIN_DIR' ) ) && file_exists( $bin_dir . '/wp' ) && is_executable( $bin_dir . '/wp' ) ) {
+				$phar_path = $bin_dir . '/wp';
+			} else {
+				$src_dir = dirname( dirname( __DIR__ ) );
+				$bin_path = $src_dir . '/bin/wp';
+				$vendor_bin_path = $src_dir . '/vendor/bin/wp';
+				if ( file_exists( $bin_path ) && is_executable( $bin_path ) ) {
+					$shell_path = $bin_path;
+				} elseif ( file_exists( $vendor_bin_path ) && is_executable( $vendor_bin_path ) ) {
+					$shell_path = $vendor_bin_path;
+				} else {
+					$shell_path = 'wp';
+				}
+			}
+		}
+
+		$str = preg_replace_callback( '/{INVOKE_WP_CLI_WITH_PHP_ARGS-([^}]*)}/', function ( $matches ) use ( $phar_path, $shell_path ) {
+			return $phar_path ? "php {$matches[1]} {$phar_path}" : ( 'WP_CLI_PHP_ARGS=' . escapeshellarg( $matches[1] ) . ' ' . $shell_path );
+		}, $str );
+
+		return $str;
 	}
 
 	/**
 	 * Replace variables callback.
 	 */
-	private function _replace_var( $matches ) {
+	private function replace_var( $matches ) {
 		$cmd = $matches[0];
 
 		foreach ( array_slice( $matches, 1 ) as $key ) {
@@ -352,9 +389,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 	}
 
 	/**
-	 * Substitute "{WP_VERSION-version-latest}" variables.
+	 * Substitute {WP_VERSION-version-latest} variables.
 	 */
-	private function _replace_wp_versions( $str ) {
+	private function replace_wp_versions( $str ) {
 		static $wp_versions = null;
 		if ( null === $wp_versions ) {
 			$wp_versions = array();

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -352,7 +352,9 @@ class FeatureContext extends BehatContext implements ClosuredContextInterface {
 
 		if ( null === $phar_path ) {
 			$phar_path = false;
-			if ( ( $bin_dir = getenv( 'WP_CLI_BIN_DIR' ) ) && file_exists( $bin_dir . '/wp' ) && is_executable( $bin_dir . '/wp' ) ) {
+			$phar_begin = '#!/usr/bin/env php';
+			$phar_begin_len = strlen( $phar_begin );
+			if ( ( $bin_dir = getenv( 'WP_CLI_BIN_DIR' ) ) && file_exists( $bin_dir . '/wp' ) && $phar_begin === file_get_contents( $bin_dir . '/wp', false, null, 0, $phar_begin_len ) ) {
 				$phar_path = $bin_dir . '/wp';
 			} else {
 				$src_dir = dirname( dirname( __DIR__ ) );

--- a/features/bootstrap/Process.php
+++ b/features/bootstrap/Process.php
@@ -2,6 +2,8 @@
 
 namespace WP_CLI;
 
+use WP_CLI\Utils;
+
 /**
  * Run a system process, and learn what happened.
  */
@@ -67,7 +69,7 @@ class Process {
 	public function run() {
 		$start_time = microtime( true );
 
-		$proc = proc_open( $this->command, self::$descriptors, $pipes, $this->cwd, $this->env );
+		$proc = Utils\proc_open_compat( $this->command, self::$descriptors, $pipes, $this->cwd, $this->env );
 
 		$stdout = stream_get_contents( $pipes[1] );
 		fclose( $pipes[1] );

--- a/features/bootstrap/utils.php
+++ b/features/bootstrap/utils.php
@@ -383,15 +383,11 @@ function launch_editor_for_input( $input, $filename = 'WP-CLI' ) {
 
 	$editor = getenv( 'EDITOR' );
 	if ( ! $editor ) {
-		$editor = 'vi';
-
-		if ( isset( $_SERVER['OS'] ) && false !== strpos( $_SERVER['OS'], 'indows' ) ) {
-			$editor = 'notepad';
-		}
+		$editor = is_windows() ? 'notepad' : 'vi';
 	}
 
 	$descriptorspec = array( STDIN, STDOUT, STDERR );
-	$process = proc_open( "$editor " . escapeshellarg( $tmpfile ), $descriptorspec, $pipes );
+	$process = proc_open_compat( "$editor " . escapeshellarg( $tmpfile ), $descriptorspec, $pipes );
 	$r = proc_close( $process );
 	if ( $r ) {
 		exit( $r );
@@ -453,7 +449,7 @@ function run_mysql_command( $cmd, $assoc_args, $descriptors = null ) {
 
 	$final_cmd = force_env_on_nix_systems( $cmd ) . assoc_args_to_str( $assoc_args );
 
-	$proc = proc_open( $final_cmd, $descriptors, $pipes );
+	$proc = proc_open_compat( $final_cmd, $descriptors, $pipes );
 	if ( ! $proc ) {
 		exit( 1 );
 	}
@@ -790,14 +786,8 @@ function get_temp_dir() {
 		return $temp;
 	}
 
-	$temp = '/tmp/';
-
-	// `sys_get_temp_dir()` introduced PHP 5.2.1.
-	if ( $try = sys_get_temp_dir() ) {
-		$temp = trailingslashit( $try );
-	} elseif ( $try = ini_get( 'upload_tmp_dir' ) ) {
-		$temp = trailingslashit( $try );
-	}
+	// `sys_get_temp_dir()` introduced PHP 5.2.1. Will always return something.
+	$temp = trailingslashit( sys_get_temp_dir() );
 
 	if ( ! is_writable( $temp ) ) {
 		\WP_CLI::warning( "Temp directory isn't writable: {$temp}" );
@@ -1129,7 +1119,7 @@ function get_suggestion( $target, array $options, $threshold = 2 ) {
 		'v' => 'version',
 	);
 
-	if ( array_key_exists( $target, $suggestion_map ) ) {
+	if ( array_key_exists( $target, $suggestion_map ) && in_array( $suggestion_map[ $target ], $options, true ) ) {
 		return $suggestion_map[ $target ];
 	}
 
@@ -1317,4 +1307,51 @@ function get_php_binary() {
 	}
 
 	return 'php';
+}
+
+/**
+ * Windows compatible `proc_open()`.
+ * Works around bug in PHP, and also deals with *nix-like `ENV_VAR=blah cmd` environment variable prefixes.
+ *
+ * @access public
+ *
+ * @param string $command Command to execute.
+ * @param array $descriptorspec Indexed array of descriptor numbers and their values.
+ * @param array &$pipes Indexed array of file pointers that correspond to PHP's end of any pipes that are created.
+ * @param string $cwd Initial working directory for the command.
+ * @param array $env Array of environment variables.
+ * @param array $other_options Array of additional options (Windows only).
+ *
+ * @return string Command stripped of any environment variable settings.
+ */
+function proc_open_compat( $cmd, $descriptorspec, &$pipes, $cwd = null, $env = null, $other_options = null ) {
+	if ( is_windows() ) {
+		// Need to encompass the whole command in double quotes - PHP bug https://bugs.php.net/bug.php?id=49139
+		$cmd = '"' . _proc_open_compat_win_env( $cmd, $env ) . '"';
+	}
+	return proc_open( $cmd, $descriptorspec, $pipes, $cwd, $env, $other_options );
+}
+
+/**
+ * For use by `proc_open_compat()` only. Separated out for ease of testing. Windows only.
+ * Turns *nix-like `ENV_VAR=blah command` environment variable prefixes into stripped `cmd` with prefixed environment variables added to passed in environment array.
+ *
+ * @access private
+ *
+ * @param string $command Command to execute.
+ * @param array &$env Array of existing environment variables. Will be modified if any settings in command.
+ *
+ * @return string Command stripped of any environment variable settings.
+ */
+function _proc_open_compat_win_env( $cmd, &$env ) {
+	if ( false !== strpos( $cmd, '=' ) ) {
+		while ( preg_match( '/^([A-Za-z_][A-Za-z0-9_]*)=("[^"]*"|[^ ]*) /', $cmd, $matches ) ) {
+			$cmd = substr( $cmd, strlen( $matches[0] ) );
+			if ( null === $env ) {
+				$env = array();
+			}
+			$env[ $matches[1] ] = isset( $matches[2][0] ) && '"' === $matches[2][0] ? substr( $matches[2], 1, -1 ) : $matches[2];
+		}
+	}
+	return $cmd;
 }

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -588,7 +588,7 @@ Feature: Install WP-CLI packages
       rocket
       """
 
-  Scenario: Install a package in a local zip
+  Scenario: Install a package from a local zip
     Given an empty directory
     And I run `wget -q -O google-sitemap-generator-cli.zip https://github.com/wp-cli/google-sitemap-generator-cli/archive/master.zip`
 

--- a/features/package.feature
+++ b/features/package.feature
@@ -59,7 +59,7 @@ Feature: Manage WP-CLI packages
 
   Scenario: Revert the WP-CLI packages composer.json when fail to install/uninstall a package due to memory limit
     Given an empty directory
-    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M} package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M -ddisable_functions=ini_set} package install danielbachhuber/wp-cli-reset-post-date-command`
     Then the return code should not be 0
     And STDERR should contain:
       """
@@ -72,7 +72,7 @@ Feature: Manage WP-CLI packages
       Success: Package installed.
       """
 
-    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M} package uninstall danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M -ddisable_functions=ini_set} package uninstall danielbachhuber/wp-cli-reset-post-date-command`
     Then the return code should not be 0
     And STDERR should contain:
       """
@@ -84,7 +84,7 @@ Feature: Manage WP-CLI packages
     Then the {RUN_DIR}/mypackages/composer.json file should exist
     And save the {RUN_DIR}/mypackages/composer.json file as {MYPACKAGES_COMPOSER_JSON}
 
-    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages {INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M} package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages {INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M -ddisable_functions=ini_set} package install danielbachhuber/wp-cli-reset-post-date-command`
     Then the return code should not be 0
     And STDERR should contain:
       """

--- a/features/package.feature
+++ b/features/package.feature
@@ -59,8 +59,7 @@ Feature: Manage WP-CLI packages
 
   Scenario: Revert the WP-CLI packages composer.json when fail to install/uninstall a package due to memory limit
     Given an empty directory
-    #When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M} package install danielbachhuber/wp-cli-reset-post-date-command`
-    When I try `WP_CLI_PHP_ARGS='-dmemory_limit=32M' {SRC_DIR}/vendor/bin/wp package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M} package install danielbachhuber/wp-cli-reset-post-date-command`
     Then the return code should not be 0
     And STDERR should contain:
       """
@@ -73,8 +72,7 @@ Feature: Manage WP-CLI packages
       Success: Package installed.
       """
 
-    #When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M} package uninstall danielbachhuber/wp-cli-reset-post-date-command`
-    When I try `WP_CLI_PHP_ARGS='-dmemory_limit=32M' {SRC_DIR}/vendor/bin/wp package uninstall danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M} package uninstall danielbachhuber/wp-cli-reset-post-date-command`
     Then the return code should not be 0
     And STDERR should contain:
       """
@@ -86,8 +84,7 @@ Feature: Manage WP-CLI packages
     Then the {RUN_DIR}/mypackages/composer.json file should exist
     And save the {RUN_DIR}/mypackages/composer.json file as {MYPACKAGES_COMPOSER_JSON}
 
-    #When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages {INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M} package install danielbachhuber/wp-cli-reset-post-date-command`
-    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages WP_CLI_PHP_ARGS='-dmemory_limit=32M' {SRC_DIR}/vendor/bin/wp package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages {INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M} package install danielbachhuber/wp-cli-reset-post-date-command`
     Then the return code should not be 0
     And STDERR should contain:
       """

--- a/features/package.feature
+++ b/features/package.feature
@@ -70,3 +70,155 @@ Feature: Manage WP-CLI packages
       """
       is not a file in phar
       """
+
+  Scenario: Revert the WP-CLI packages composer.json when fail to install/uninstall a package due to memory limit
+    Given an empty directory
+    #When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M} package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `WP_CLI_PHP_ARGS='-dmemory_limit=32M' {SRC_DIR}/vendor/bin/wp package install danielbachhuber/wp-cli-reset-post-date-command`
+    Then the return code should not be 0
+    And STDERR should contain:
+      """
+      Reverted composer.json.
+      """
+
+    When I run `wp package install danielbachhuber/wp-cli-reset-post-date-command`
+    Then STDOUT should contain:
+      """
+      Success: Package installed.
+      """
+
+    #When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M} package uninstall danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `WP_CLI_PHP_ARGS='-dmemory_limit=32M' {SRC_DIR}/vendor/bin/wp package uninstall danielbachhuber/wp-cli-reset-post-date-command`
+    Then the return code should not be 0
+    And STDERR should contain:
+      """
+      Reverted composer.json.
+      """
+
+    # Create a default composer.json first to compare.
+    When I run `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages wp package list`
+	Then the {RUN_DIR}/mypackages/composer.json file should exist
+    And save the {RUN_DIR}/mypackages/composer.json file as {MYPACKAGES_COMPOSER_JSON}
+
+    #When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages {INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M} package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages WP_CLI_PHP_ARGS='-dmemory_limit=32M' {SRC_DIR}/vendor/bin/wp package install danielbachhuber/wp-cli-reset-post-date-command`
+    Then the return code should not be 0
+    And STDERR should contain:
+      """
+      Reverted composer.json.
+      """
+    And the mypackages/composer.json file should be:
+      """
+      {MYPACKAGES_COMPOSER_JSON}
+      """
+
+  Scenario: Try to run with a bad WP_CLI_PACKAGES_DIR/composer.json
+    Given an empty directory
+    And a packages-bad-json/composer.json file:
+      """
+      {
+        "name": "wp-cli/wp-cli",
+      }
+      """
+    And a packages-no-such-package/composer.json file:
+      """
+      {
+        "name": "wp-cli/wp-cli",
+        "repositories": {
+          "no-such-gituser/no-such-package": {
+             "type": "vcs",
+             "url": "https://github.com/no-such-gituser/no-such-package.git"
+          }
+        },
+        "require": {
+          "no-such-gituser/no-such-package": "dev-master"
+        }
+      }
+      """
+    And save the {RUN_DIR}/packages-no-such-package/composer.json file as {NO_SUCH_PACKAGE_COMPOSER_JSON}
+
+    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/packages-bad-json wp package list`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      Error: Failed to get composer instance
+      """
+    And STDERR should contain:
+      """
+      Parse error
+      """
+    And STDOUT should be empty
+
+    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/packages-bad-json wp package install danielbachhuber/wp-cli-reset-post-date-command`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      Error: Failed to parse
+      """
+    And STDERR should contain:
+      """
+      Parse error
+      """
+    And STDOUT should contain:
+      """
+      Installing
+      """
+
+    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/packages-bad-json wp package update`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      Error: Failed to get composer instance
+      """
+    And STDERR should contain:
+      """
+      Parse error
+      """
+    And STDOUT should be empty
+    And the packages-no-such-package/composer.json file should be:
+      """
+      {NO_SUCH_PACKAGE_COMPOSER_JSON}
+      """
+
+    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/packages-no-such-package wp package install danielbachhuber/wp-cli-reset-post-date-command`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      Error: Package installation failed.
+      """
+    And STDERR should contain:
+      """
+      Repository not found
+      """
+    And STDERR should contain:
+      """
+      Reverted composer.json.
+      """
+    And STDOUT should contain:
+      """
+      Installing
+      """
+    And the packages-no-such-package/composer.json file should be:
+      """
+      {NO_SUCH_PACKAGE_COMPOSER_JSON}
+      """
+
+    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/packages-no-such-package wp package update`
+    Then the return code should be 1
+    And STDERR should contain:
+      """
+      Error: Failed to update packages.
+      """
+    And STDERR should contain:
+      """
+      Repository not found
+      """
+    And STDERR should not contain:
+      """
+      Reverted composer.json.
+      """
+    And STDOUT should not be empty
+    And the packages-no-such-package/composer.json file should be:
+      """
+      {NO_SUCH_PACKAGE_COMPOSER_JSON}
+      """

--- a/features/package.feature
+++ b/features/package.feature
@@ -97,7 +97,7 @@ Feature: Manage WP-CLI packages
 
     # Create a default composer.json first to compare.
     When I run `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages wp package list`
-	Then the {RUN_DIR}/mypackages/composer.json file should exist
+    Then the {RUN_DIR}/mypackages/composer.json file should exist
     And save the {RUN_DIR}/mypackages/composer.json file as {MYPACKAGES_COMPOSER_JSON}
 
     #When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages {INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M} package install danielbachhuber/wp-cli-reset-post-date-command`

--- a/features/package.feature
+++ b/features/package.feature
@@ -98,6 +98,7 @@ Feature: Manage WP-CLI packages
       {MYPACKAGES_COMPOSER_JSON}
       """
 
+  @github-api
   Scenario: Try to run with a bad WP_CLI_PACKAGES_DIR/composer.json
     Given an empty directory
     And a packages-bad-json/composer.json file:
@@ -106,22 +107,6 @@ Feature: Manage WP-CLI packages
         "name": "wp-cli/wp-cli",
       }
       """
-    And a packages-no-such-package/composer.json file:
-      """
-      {
-        "name": "wp-cli/wp-cli",
-        "repositories": {
-          "no-such-gituser/no-such-package": {
-             "type": "vcs",
-             "url": "https://github.com/no-such-gituser/no-such-package.git"
-          }
-        },
-        "require": {
-          "no-such-gituser/no-such-package": "dev-master"
-        }
-      }
-      """
-    And save the {RUN_DIR}/packages-no-such-package/composer.json file as {NO_SUCH_PACKAGE_COMPOSER_JSON}
 
     When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/packages-bad-json wp package list`
     Then the return code should be 1
@@ -161,10 +146,23 @@ Feature: Manage WP-CLI packages
       Parse error
       """
     And STDOUT should be empty
-    And the packages-no-such-package/composer.json file should be:
+
+    Given a packages-no-such-package/composer.json file:
       """
-      {NO_SUCH_PACKAGE_COMPOSER_JSON}
+      {
+        "name": "wp-cli/wp-cli",
+        "repositories": {
+          "no-such-gituser/no-such-package": {
+             "type": "vcs",
+             "url": "https://github.com/no-such-gituser/no-such-package.git"
+          }
+        },
+        "require": {
+          "no-such-gituser/no-such-package": "dev-master"
+        }
+      }
       """
+    And save the {RUN_DIR}/packages-no-such-package/composer.json file as {NO_SUCH_PACKAGE_COMPOSER_JSON}
 
     When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/packages-no-such-package wp package install danielbachhuber/wp-cli-reset-post-date-command`
     Then the return code should be 1

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -842,7 +842,7 @@ class Package_Command extends WP_CLI_Command {
 				$composer_path = realpath( $composer_path );
 				if ( false === $composer_path ) {
 					$error = error_get_last();
-					WP_CLI::error( sprintf( "Composer directory '%s' for packages not found: %s", $composer_dir, $error['message'] ) );
+					WP_CLI::error( sprintf( "Composer path '%s' for packages/composer.json not found: %s", $composer_path, $error['message'] ) );
 				}
 			}
 		}

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -288,11 +288,15 @@ class Package_Command extends WP_CLI_Command {
 
 		WP_CLI::log( sprintf( "Installing package %s (%s)", $package_name, $version ) );
 
-		$composer_json_obj = $this->get_composer_json();
+		// Read the WP-CLI packages composer.json and do some initial error checking.
+		list( $json_path, $composer_backup, $composer_backup_decoded ) = $this->get_composer_json_path_backup_decoded();
+
+		// Revert on shutdown if `$revert` is true (set to false on success).
+		$revert = true;
+		$this->register_revert_shutdown_function( $json_path, $composer_backup, $revert );
 
 		// Add the 'require' to composer.json
-		WP_CLI::log( sprintf( "Updating %s to require the package...", $composer_json_obj->getPath() ) );
-		$composer_backup = file_get_contents( $composer_json_obj->getPath() );
+		WP_CLI::log( sprintf( "Updating %s to require the package...", $json_path ) );
 		$json_manipulator = new JsonManipulator( $composer_backup );
 		$json_manipulator->addMainKey( 'name', 'wp-cli/wp-cli' );
 		$json_manipulator->addMainKey( 'version', self::get_wp_cli_version_composer() );
@@ -306,19 +310,14 @@ class Package_Command extends WP_CLI_Command {
 			WP_CLI::log( sprintf( 'Registering %s as a path repository...', $dir_package ) );
 			$json_manipulator->addSubNode( 'repositories', $package_name, array( 'type' => 'path', 'url' => $dir_package ), true /*caseInsensitive*/ );
 		}
-		$composer_backup_decoded = json_decode( $composer_backup, true );
 		// If the composer file does not contain the current package index repository, refresh the repository definition.
 		if ( empty( $composer_backup_decoded['repositories']['wp-cli']['url'] ) || self::PACKAGE_INDEX_URL != $composer_backup_decoded['repositories']['wp-cli']['url'] ) {
 			WP_CLI::log( 'Updating package index repository url...' );
 			$json_manipulator->addRepository( 'wp-cli', array( 'type' => 'composer', 'url' => self::PACKAGE_INDEX_URL ) );
 		}
 
-		file_put_contents( $composer_json_obj->getPath(), $json_manipulator->getContents() );
-		try {
-			$composer = $this->get_composer();
-		} catch( Exception $e ) {
-			WP_CLI::error( $e->getMessage() );
-		}
+		file_put_contents( $json_path, $json_manipulator->getContents() );
+		$composer = $this->get_composer();
 
 		// Set up the EventSubscriber
 		$event_subscriber = new \WP_CLI\PackageManagerEventSubscriber;
@@ -340,11 +339,11 @@ class Package_Command extends WP_CLI_Command {
 		WP_CLI::log( '---' );
 
 		if ( 0 === $res ) {
+			$revert = false;
 			WP_CLI::success( "Package installed." );
 		} else {
-			file_put_contents( $composer_json_obj->getPath(), $composer_backup );
 			$res_msg = $res ? " (Composer return code {$res})" : ''; // $res may be null apparently.
-			WP_CLI::error( "Package installation failed{$res_msg}. Reverted composer.json" );
+			WP_CLI::error( "Package installation failed{$res_msg}." );
 		}
 	}
 
@@ -450,11 +449,8 @@ class Package_Command extends WP_CLI_Command {
 	 */
 	public function update() {
 		$this->set_composer_auth_env_var();
-		try {
-			$composer = $this->get_composer();
-		} catch( Exception $e ) {
-			WP_CLI::error( $e->getMessage() );
-		}
+		$composer = $this->get_composer();
+
 		// Set up the EventSubscriber
 		$event_subscriber = new \WP_CLI\PackageManagerEventSubscriber;
 		$composer->getEventDispatcher()->addSubscriber( $event_subscriber );
@@ -501,22 +497,20 @@ class Package_Command extends WP_CLI_Command {
 		list( $package_name ) = $args;
 
 		$this->set_composer_auth_env_var();
-		try {
-			$composer = $this->get_composer();
-		} catch( Exception $e ) {
-			WP_CLI::error( $e->getMessage() );
-		}
 		if ( false === ( $package = $this->get_installed_package_by_name( $package_name ) ) ) {
 			WP_CLI::error( "Package not installed." );
 		}
 		$package_name = $package->getPrettyName(); // Make sure package name is what's in composer.json.
 
-		$composer_json_obj = $this->get_composer_json();
+		// Read the WP-CLI packages composer.json and do some initial error checking.
+		list( $json_path, $composer_backup, $composer_backup_decoded ) = $this->get_composer_json_path_backup_decoded();
+
+		// Revert on shutdown if `$revert` is true (set to false on success).
+		$revert = true;
+		$this->register_revert_shutdown_function( $json_path, $composer_backup, $revert );
 
 		// Remove the 'require' from composer.json.
-		$json_path = $composer_json_obj->getPath();
 		WP_CLI::log( sprintf( 'Removing require statement from %s', $json_path ) );
-		$composer_backup = file_get_contents( $composer_json_obj->getPath() );
 		$manipulator = new JsonManipulator( $composer_backup );
 		$manipulator->removeSubNode( 'require', $package_name, true /*caseInsensitive*/ );
 
@@ -524,13 +518,8 @@ class Package_Command extends WP_CLI_Command {
 		WP_CLI::log( sprintf( 'Removing repository details from %s', $json_path ) );
 		$manipulator->removeSubNode( 'repositories', $package_name, true /*caseInsensitive*/ );
 
-		file_put_contents( $composer_json_obj->getPath(), $manipulator->getContents() );
-
-		try {
-			$composer = $this->get_composer();
-		} catch ( Exception $e ) {
-			WP_CLI::error( $e->getMessage() );
-		}
+		file_put_contents( $json_path, $manipulator->getContents() );
+		$composer = $this->get_composer();
 
 		// Set up the installer.
 		$install = Installer::create( new NullIO, $composer );
@@ -546,9 +535,9 @@ class Package_Command extends WP_CLI_Command {
 		}
 
 		if ( 0 === $res ) {
+			$revert = false;
 			WP_CLI::success( "Uninstalled package." );
 		} else {
-			file_put_contents( $composer_json_obj->getPath(), $composer_backup );
 			$res_msg = $res ? " (Composer return code {$res})" : ''; // $res may be null apparently.
 			WP_CLI::error( "Package removal failed{$res_msg}." );
 		}
@@ -569,17 +558,22 @@ class Package_Command extends WP_CLI_Command {
 	 * Gets a Composer instance.
 	 */
 	private function get_composer() {
-		$composer_path = $this->get_composer_json_path();
+		try {
+			$composer_path = $this->get_composer_json_path();
 
-		// Composer's auto-load generating code makes some assumptions about where
-		// the 'vendor-dir' is, and where Composer is running from.
-		// Best to just pretend we're installing a package from ~/.wp-cli or similar
-		chdir( pathinfo( $composer_path, PATHINFO_DIRNAME ) );
+			// Composer's auto-load generating code makes some assumptions about where
+			// the 'vendor-dir' is, and where Composer is running from.
+			// Best to just pretend we're installing a package from ~/.wp-cli or similar
+			chdir( pathinfo( $composer_path, PATHINFO_DIRNAME ) );
 
-		// Prevent DateTime error/warning when no timezone set
-		date_default_timezone_set( @date_default_timezone_get() );
+			// Prevent DateTime error/warning when no timezone set
+			date_default_timezone_set( @date_default_timezone_get() );
 
-		return Factory::create( new NullIO, $composer_path );
+			$composer = Factory::create( new NullIO, $composer_path );
+		} catch ( Exception $e ) {
+			WP_CLI::error( sprintf( 'Failed to get composer instance: %s', $e->getMessage() ) );
+		}
+		return $composer;
 	}
 
 	/**
@@ -662,6 +656,7 @@ class Package_Command extends WP_CLI_Command {
 		);
 		$assoc_args = array_merge( $defaults, $assoc_args );
 
+		$composer = $this->get_composer();
 		$list = array();
 		foreach ( $packages as $package ) {
 			$name = $package->getPrettyName();
@@ -677,7 +672,7 @@ class Package_Command extends WP_CLI_Command {
 				$update_version = '';
 				if ( 'list' === $context ) {
 					try {
-						$latest = $this->find_latest_package( $package, $this->get_composer(), null );
+						$latest = $this->find_latest_package( $package, $composer, null );
 						if ( $latest && $latest->getFullPrettyVersion() !== $package->getFullPrettyVersion() ) {
 							$update = 'available';
 							$update_version = $latest->getPrettyVersion();
@@ -743,11 +738,8 @@ class Package_Command extends WP_CLI_Command {
 	 * Gets the installed community packages.
 	 */
 	private function get_installed_packages() {
-		try {
-			$composer = $this->get_composer();
-		} catch( Exception $e ) {
-			WP_CLI::error( $e->getMessage() );
-		}
+		$composer = $this->get_composer();
+
 		$repo = $composer->getRepositoryManager()->getLocalRepository();
 		$existing = json_decode( file_get_contents( $this->get_composer_json_path() ), true );
 		$installed_package_keys = ! empty( $existing['require'] ) ? array_keys( $existing['require'] ) : array();
@@ -823,35 +815,35 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Gets the composer.json object
+	 * Gets the WP-CLI packages composer.json object.
 	 */
 	private function get_composer_json() {
 		return new JsonFile( $this->get_composer_json_path() );
 	}
 
 	/**
-	 * Gets the path to composer.json
+	 * Gets the absolute path to the WP-CLI packages composer.json.
 	 */
 	private function get_composer_json_path() {
 		static $composer_path;
 
-		if ( null === $composer_path ) {
+		if ( null === $composer_path || getenv( 'WP_CLI_TEST_PACKAGE_GET_COMPOSER_JSON_PATH' ) ) {
 
 			if ( getenv( 'WP_CLI_PACKAGES_DIR' ) ) {
-				$composer_path = rtrim( getenv( 'WP_CLI_PACKAGES_DIR' ), '/' ) . '/composer.json';
+				$composer_path = Utils\trailingslashit( getenv( 'WP_CLI_PACKAGES_DIR' ) ) . 'composer.json';
 			} else {
-				$home = getenv( 'HOME' );
-				if ( ! $home ) {
-					// In Windows $HOME may not be defined
-					$home = getenv( 'HOMEDRIVE' ) . getenv( 'HOMEPATH' );
-				}
-
-				$composer_path = rtrim( $home, '/\\' ) . '/.wp-cli/packages/composer.json';
+				$composer_path = Utils\trailingslashit( Utils\get_home_dir() ) . '.wp-cli/packages/composer.json';
 			}
 
 			// `composer.json` and its directory might need to be created
 			if ( ! file_exists( $composer_path ) ) {
-				$this->create_default_composer_json( $composer_path );
+				$composer_path = $this->create_default_composer_json( $composer_path );
+			} else {
+				$composer_path = realpath( $composer_path );
+				if ( false === $composer_path ) {
+					$error = error_get_last();
+					WP_CLI::error( sprintf( "Composer directory '%s' for packages not found: %s", $composer_dir, $error['message'] ) );
+				}
 			}
 		}
 
@@ -867,21 +859,28 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Creates a default composer.json, should one not already exist
+	 * Creates a default WP-CLI packages composer.json.
 	 *
 	 * @param string $composer_path Where the composer.json should be created
-	 * @return true|WP_Error
+	 * @return string Returns the absolute path of the newly created default WP-CLI packages composer.json.
 	 */
 	private function create_default_composer_json( $composer_path ) {
 
 		$composer_dir = pathinfo( $composer_path, PATHINFO_DIRNAME );
 		if ( ! is_dir( $composer_dir ) ) {
-			\WP_CLI\Process::create( WP_CLI\Utils\esc_cmd( 'mkdir -p %s', $composer_dir ) )->run();
+			if ( ! @mkdir( $composer_dir, 0777, true ) ) { // @codingStandardsIgnoreLine
+				$error = error_get_last();
+				WP_CLI::error( sprintf( "Composer directory '%s' for packages couldn't be created: %s", $composer_dir, $error['message'] ) );
+			}
 		}
 
-		if ( ! is_dir( $composer_dir ) ) {
-			WP_CLI::error( "Composer directory for packages couldn't be created." );
+		$composer_dir = realpath( $composer_dir );
+		if ( false === $composer_dir ) {
+			$error = error_get_last();
+			WP_CLI::error( sprintf( "Composer directory '%s' for packages not found: %s", $composer_dir, $error['message'] ) );
 		}
+
+		$composer_path = Utils\trailingslashit( $composer_dir ) . Utils\basename( $composer_path );
 
 		$json_file = new JsonFile( $composer_path );
 
@@ -916,7 +915,7 @@ class Package_Command extends WP_CLI_Command {
 			WP_CLI::error( $e->getMessage() );
 		}
 
-		return true;
+		return $composer_path;
 	}
 
 	/**
@@ -1022,5 +1021,50 @@ class Package_Command extends WP_CLI_Command {
 		if ( $changed ) {
 			putenv( 'COMPOSER_AUTH=' . json_encode( $composer_auth ) );
 		}
+	}
+
+	/**
+	 * Reads the WP-CLI packages composer.json, checking validity and returning array containing its path, contents, and decoded contents.
+	 *
+	 * @return array Indexed array containing the path, the contents, and the decoded contents of the WP-CLI packages composer.json.
+	 */
+	private function get_composer_json_path_backup_decoded() {
+		$composer_json_obj = $this->get_composer_json();
+		$json_path = $composer_json_obj->getPath();
+		$composer_backup = file_get_contents( $json_path );
+		if ( false === $composer_backup ) {
+			$error = error_get_last();
+			WP_CLI::error( sprintf( "Failed to read '%s': %s", $json_path, $error['message'] ) );
+		}
+		try {
+			$composer_backup_decoded = $composer_json_obj->read();
+		} catch ( Exception $e ) {
+			WP_CLI::error( sprintf( "Failed to parse '%s' as json: %s", $json_path, $e->getMessage() ) );
+		}
+
+		return array( $json_path, $composer_backup, $composer_backup_decoded );
+	}
+
+	/**
+	 * Registers a PHP shutdown function to revert composer.json unless referenced `$revert` flag is false.
+	 *
+	 * @param string $json_path Path to composer.json.
+	 * @param string $json_path Original contents of composer.json.
+	 * @param bool &$revert Flags whether to revert or not.
+	 */
+	private function register_revert_shutdown_function( $json_path, $composer_backup, &$revert ) {
+		// Allocate all needed memory beforehand as much as possible.
+		$revert_msg = "Reverted composer.json." . PHP_EOL;
+		$revert_fail_msg = "Failed to revert composer.json." . PHP_EOL;
+
+		register_shutdown_function( function () use ( $json_path, $composer_backup, &$revert, $revert_msg, $revert_fail_msg ) {
+			if ( $revert ) {
+				if ( false === file_put_contents( $json_path, $composer_backup ) ) {
+					fwrite( STDERR,  $revert_fail_msg );
+				} else {
+					fwrite( STDERR, $revert_msg );
+				}
+			}
+		} );
 	}
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,3 +17,4 @@ if ( file_exists( WP_CLI_ROOT . '/vendor/autoload.php' ) ) {
 
 require_once WP_CLI_VENDOR_DIR . '/autoload.php';
 
+define( 'WP_CLI_VERSION', trim( file_get_contents( WP_CLI_VENDOR_DIR . '/wp-cli/wp-cli/VERSION' ) ) );

--- a/tests/test-composer-json.php
+++ b/tests/test-composer-json.php
@@ -1,0 +1,179 @@
+<?php
+
+use WP_CLI\Utils;
+
+require_once WP_CLI_VENDOR_DIR . '/wp-cli/wp-cli/php/utils.php';
+require_once WP_CLI_VENDOR_DIR . '/wp-cli/wp-cli/php/class-wp-cli.php';
+require_once WP_CLI_VENDOR_DIR . '/wp-cli/wp-cli/php/class-wp-cli-command.php';
+
+class ComposerJsonTest extends PHPUnit_Framework_TestCase {
+
+	var $logger = null;
+	var $prev_logger = null;
+	var $prev_capture_exit = null;
+	var $temp_dir = null;
+
+	public function setUp() {
+		parent::setUp();
+
+		// Save and set logger.
+		$class_wp_cli_logger = new \ReflectionProperty( 'WP_CLI', 'logger' );
+		$class_wp_cli_logger->setAccessible( true );
+		$this->prev_logger = $class_wp_cli_logger->getValue();
+
+		$this->logger = new \WP_CLI\Loggers\Execution;
+		WP_CLI::set_logger( $this->logger );
+
+		// Enable exit exception.
+		$class_wp_cli_capture_exit = new \ReflectionProperty( 'WP_CLI', 'capture_exit' );
+		$class_wp_cli_capture_exit->setAccessible( true );
+		$this->prev_capture_exit = $class_wp_cli_capture_exit->getValue();
+		$class_wp_cli_capture_exit->setValue( true );
+
+		$this->temp_dir = Utils\get_temp_dir() . uniqid( 'wp-cli-test-package-composer-json-', true ) . '/';
+		mkdir( $this->temp_dir );
+	}
+
+	public function tearDown() {
+		// Restore logger.
+		WP_CLI::set_logger( $this->prev_logger );
+
+		// Restore exit exception.
+		$class_wp_cli_capture_exit = new \ReflectionProperty( 'WP_CLI', 'capture_exit' );
+		$class_wp_cli_capture_exit->setAccessible( true );
+		$class_wp_cli_capture_exit->setValue( $this->prev_capture_exit );
+
+		rmdir( $this->temp_dir );
+
+		parent::tearDown();
+	}
+
+	function test_create_default_composer_json() {
+		$create_default_composer_json = new \ReflectionMethod( 'Package_Command', 'create_default_composer_json' );
+		$create_default_composer_json->setAccessible( true );
+
+		$package = new Package_Command;
+
+		// Fail with bad directory.
+		$exception = null;
+		try {
+			$actual = $create_default_composer_json->invoke( $package, '' );
+		} catch ( \WP_CLI\ExitException $ex ) {
+			$exception = $ex;
+		}
+		$this->assertTrue( null !== $exception );
+		$this->assertTrue( 1 === $exception->getCode() );
+		$this->assertTrue( empty( $this->logger->stdout ) );
+		$this->assertTrue( false !== strpos( $this->logger->stderr, 'Error: Composer directory' ) );
+
+		// Succeed.
+		$expected = $this->temp_dir . 'packages/composer.json';
+		$actual = $create_default_composer_json->invoke( $package, $expected );
+		$this->assertSame( $expected, $actual );
+		$this->assertTrue( false !== strpos( file_get_contents( $actual ), 'wp-cli/wp-cli' ) );
+		unlink( $actual );
+		rmdir( dirname( $actual ) );
+	}
+
+	function test_get_composer_json_path() {
+		$env_test = getenv( 'WP_CLI_TEST_PACKAGE_GET_COMPOSER_JSON_PATH' );
+		$env_home = getenv( 'HOME' );
+		$env_wp_cli_packages_dir = getenv( 'WP_CLI_PACKAGES_DIR' );
+
+		$get_composer_json_path = new \ReflectionMethod( 'Package_Command', 'get_composer_json_path' );
+		$get_composer_json_path->setAccessible( true );
+
+		$package = new Package_Command;
+
+		putenv( 'WP_CLI_TEST_PACKAGE_GET_COMPOSER_JSON_PATH=1' );
+		putenv( 'HOME=' . $this->temp_dir );
+
+		// Create in HOME.
+		putenv( 'WP_CLI_PACKAGES_DIR' );
+		$expected = $this->temp_dir . '.wp-cli/packages/composer.json';
+		$actual = $get_composer_json_path->invoke( $package );
+		$this->assertSame( $expected, $actual );
+		$this->assertTrue( false !== strpos( file_get_contents( $actual ), 'wp-cli/wp-cli' ) );
+		unlink( $actual );
+		rmdir( dirname( $actual ) );
+		rmdir( dirname( dirname( $actual ) ) );
+
+		// Create in WP_CLI_PACKAGES_DIR.
+		putenv( 'WP_CLI_PACKAGES_DIR=' . $this->temp_dir . 'packages' );
+		$expected = $this->temp_dir . 'packages/composer.json';
+		$actual = $get_composer_json_path->invoke( $package );
+		$this->assertSame( $expected, $actual );
+		$this->assertTrue( false !== strpos( file_get_contents( $actual ), 'wp-cli/wp-cli' ) );
+		unlink( $actual );
+		rmdir( dirname( $actual ) );
+
+		// Do nothing as already exists.
+		putenv( 'WP_CLI_PACKAGES_DIR=' . $this->temp_dir . 'packages' );
+		$expected = $this->temp_dir . 'packages/composer.json';
+		mkdir( $this->temp_dir . 'packages' );
+		touch( $expected );
+		$actual = $get_composer_json_path->invoke( $package );
+		$this->assertSame( $expected, $actual );
+		$this->assertSame( 0, filesize( $actual ) );
+		unlink( $actual );
+		rmdir( dirname( $actual ) );
+
+		putenv( false === $env_test ? 'WP_CLI_TEST_PACKAGE_GET_COMPOSER_JSON_PATH' : "WP_CLI_TEST_PACKAGE_GET_COMPOSER_JSON_PATH=$env_test" );
+		putenv( false === $env_home ? 'HOME' : "HOME=$env_home" );
+		putenv( false === $env_wp_cli_packages_dir ? 'WP_CLI_PACKAGES_DIR' : "WP_CLI_PACKAGES_DIR=$env_wp_cli_packages_dir" );
+	}
+
+	function test_get_composer_json_path_backup_decoded() {
+		$env_test = getenv( 'WP_CLI_TEST_PACKAGE_GET_COMPOSER_JSON_PATH' );
+		$env_wp_cli_packages_dir = getenv( 'WP_CLI_PACKAGES_DIR' );
+
+		putenv( 'WP_CLI_TEST_PACKAGE_GET_COMPOSER_JSON_PATH=1' );
+		putenv( 'WP_CLI_PACKAGES_DIR=' . $this->temp_dir . 'packages' );
+
+		$get_composer_json_path_backup_decoded = new \ReflectionMethod( 'Package_Command', 'get_composer_json_path_backup_decoded' );
+		$get_composer_json_path_backup_decoded->setAccessible( true );
+
+		$package = new Package_Command;
+
+		// Fail with bad json.
+		$expected = $this->temp_dir . 'packages/composer.json';
+		mkdir( $this->temp_dir . 'packages' );
+		file_put_contents( $expected, '{' );
+		$exception = null;
+		try {
+			$actual = $get_composer_json_path_backup_decoded->invoke( $package );
+		} catch ( \WP_CLI\ExitException $ex ) {
+			$exception = $ex;
+		}
+		$this->assertTrue( null !== $exception );
+		$this->assertTrue( 1 === $exception->getCode() );
+		$this->assertTrue( empty( $this->logger->stdout ) );
+		$this->assertTrue( false !== strpos( $this->logger->stderr, 'Error: Failed to parse' ) );
+		unlink( $expected );
+		rmdir( dirname( $expected ) );
+
+		// Succeed with newly created.
+		$expected = $this->temp_dir . 'packages/composer.json';
+		list( $actual, $content, $decoded ) = $get_composer_json_path_backup_decoded->invoke( $package );
+		$this->assertSame( $expected, $actual );
+		$this->assertTrue( false !== strpos( file_get_contents( $actual ), 'wp-cli/wp-cli' ) );
+		$this->assertSame( file_get_contents( $actual ), $content );
+		$this->assertFalse( empty( $decoded ) );
+		unlink( $expected );
+		rmdir( dirname( $expected ) );
+
+		// Succeed with blank.
+		$expected = $this->temp_dir . 'packages/composer.json';
+		mkdir( $this->temp_dir . 'packages' );
+		file_put_contents( $expected, '{}' );
+		list( $actual, $content, $decoded ) = $get_composer_json_path_backup_decoded->invoke( $package );
+		$this->assertSame( $expected, $actual );
+		$this->assertSame( '{}', $content );
+		$this->assertTrue( empty( $decoded ) );
+		unlink( $expected );
+		rmdir( dirname( $expected ) );
+
+		putenv( false === $env_test ? 'WP_CLI_TEST_PACKAGE_GET_COMPOSER_JSON_PATH' : "WP_CLI_TEST_PACKAGE_GET_COMPOSER_JSON_PATH=$env_test" );
+		putenv( false === $env_wp_cli_packages_dir ? 'WP_CLI_PACKAGES_DIR' : "WP_CLI_PACKAGES_DIR=$env_wp_cli_packages_dir" );
+	}
+}


### PR DESCRIPTION
Closes #27.

Deals with PHP memory allocation failure on install/uninstall corrupting the WP-CLI packages `composer.json` by registering a shutdown function to revert to backup.

Adds 2 new helper functions `get_composer_json_path_backup_decoded()`, which reads and validates `composer.json`, and `register_revert_shutdown_function()`.

Modifies the `get_composer_json_path()` and `create_default_composer_json()` functions to return the absolute path of the `composer.json` file to simplify use, and adds some error checking and uses `Utils`.

Also unrelatedly puts try/catch processing into `get_composer()` to simplify use, and removes redundant call in `uninstall()`, and calls once outside loop in `show_packages()`.

Adds phpunit tests for the new `get_composer_json_path_backup_decoded()` function and the modified `get_composer_json_path()` and `create_default_composer_json()` functions.

Needs https://github.com/wp-cli/wp-cli/pull/4597 and a scaffold package-tests refresh before merging to use `{INVOKE_WP_CLI_WITH_PHP_ARGS-}`.