### PR TITLE
Fix package name is retrieved from wrong branch.

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -600,43 +600,43 @@ Feature: Install WP-CLI packages
   Scenario: Install a package with a composer.json that differs between versions
     Given an empty directory
 
-    When I run `wp package install gitlost/test-version-composer-json-different:v1.0.0`
+    When I run `wp package install wp-cli-test/version-composer-json-different:v1.0.0`
     Then STDOUT should contain:
       """
-      Installing package gitlost/test-version-composer-json-different (v1.0.0)
+      Installing package wp-cli-test/version-composer-json-different (v1.0.0)
       Updating {PACKAGE_PATH}composer.json to require the package...
       """
     And STDOUT should contain:
       """
       Success: Package installed.
       """
-    And the {PACKAGE_PATH}/vendor/gitlost/test-version-composer-json-different/composer.json file should exist
-    And the {PACKAGE_PATH}/vendor/gitlost/test-version-composer-json-different/composer.json file should contain:
+    And the {PACKAGE_PATH}/vendor/wp-cli-test/version-composer-json-different/composer.json file should exist
+    And the {PACKAGE_PATH}/vendor/wp-cli-test/version-composer-json-different/composer.json file should contain:
       """
       1.0.0
       """
-    And the {PACKAGE_PATH}/vendor/gitlost/test-version-composer-json-different/composer.json file should not contain:
+    And the {PACKAGE_PATH}/vendor/wp-cli-test/version-composer-json-different/composer.json file should not contain:
       """
       1.0.1
       """
     And the {PACKAGE_PATH}/vendor/wp-cli/profile-command directory should not exist
 
-    When I run `wp package install gitlost/test-version-composer-json-different:v1.0.1`
+    When I run `wp package install wp-cli-test/version-composer-json-different:v1.0.1`
     Then STDOUT should contain:
       """
-      Installing package gitlost/test-version-composer-json-different (v1.0.1)
+      Installing package wp-cli-test/version-composer-json-different (v1.0.1)
       Updating {PACKAGE_PATH}composer.json to require the package...
       """
     And STDOUT should contain:
       """
       Success: Package installed.
       """
-    And the {PACKAGE_PATH}/vendor/gitlost/test-version-composer-json-different/composer.json file should exist
-    And the {PACKAGE_PATH}/vendor/gitlost/test-version-composer-json-different/composer.json file should contain:
+    And the {PACKAGE_PATH}/vendor/wp-cli-test/version-composer-json-different/composer.json file should exist
+    And the {PACKAGE_PATH}/vendor/wp-cli-test/version-composer-json-different/composer.json file should contain:
       """
       1.0.1
       """
-    And the {PACKAGE_PATH}/vendor/gitlost/test-version-composer-json-different/composer.json file should not contain:
+    And the {PACKAGE_PATH}/vendor/wp-cli-test/version-composer-json-different/composer.json file should not contain:
       """
       1.0.0
       """

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -600,7 +600,6 @@ Feature: Install WP-CLI packages
   Scenario: Install a package with a composer.json that differs between versions
     Given an empty directory
 
-    # Need to give Composer "dev-master#v1.0.0" apparently.
     When I run `wp package install gitlost/test-version-composer-json-different:v1.0.0`
     Then STDOUT should contain:
       """

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -1010,7 +1010,7 @@ class Package_Command extends WP_CLI_Command {
 	}
 
 	/**
-	 * Get the version to use for raw github request.
+	 * Get the version to use for raw github request. Very basic.
 	 *
 	 * @string $version Package version.
 	 * @string Version to use for github request.

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -278,7 +278,7 @@ class Package_Command extends WP_CLI_Command {
 			if ( is_string( $package ) ) {
 				if ( $this->is_git_repository( $package ) ) {
 					$git_package = $package;
-					$package_name = $this->check_git_package_name( $package_name );
+					$package_name = $this->check_git_package_name( $package_name, $version );
 				}
 			} elseif ( $package_name !== $package->getPrettyName() ) {
 				// BC support for specifying lowercase names for mixed-case package index packages - don't bother warning.
@@ -973,10 +973,14 @@ class Package_Command extends WP_CLI_Command {
 
 	/**
 	 * Checks that `$package_name` matches the name in the repo composer.json, and return corrected value if not.
+	 *
+	 * @string $package_name Package name to check.
+	 * @string $version Optional. Package version. Default 'master'.
+	 * @string Package name, possibly changed to match that in repo.
 	 */
-	private function check_git_package_name( $package_name ) {
+	private function check_git_package_name( $package_name, $version = '' ) {
 		// Generate raw git URL of composer.json file.
-		$raw_content_url = 'https://raw.githubusercontent.com/' . $package_name . '/master/composer.json';
+		$raw_content_url = 'https://raw.githubusercontent.com/' . $package_name . '/' . $this->get_raw_git_version( $version ) . '/composer.json';
 		$github_token = getenv( 'GITHUB_TOKEN' ); // Use GITHUB_TOKEN if available to avoid authorization failures or rate-limiting.
 		$headers = $github_token ? array( 'Authorization' => 'token ' . $github_token ) : array();
 
@@ -1003,6 +1007,32 @@ class Package_Command extends WP_CLI_Command {
 			$package_name = $package_name_on_repo;
 		}
 		return $package_name;
+	}
+
+	/**
+	 * Get the version to use for raw github request.
+	 *
+	 * @string $version Package version.
+	 * @string Version to use for github request.
+	 */
+	private function get_raw_git_version( $version ) {
+		if ( '' !== $version ) {
+			// If Composer hash given then just use whatever's after it.
+			if ( false !== ( $hash_pos = strpos( $version, '#' ) ) ) {
+				$version = substr( $version, $hash_pos + 1 );
+			} else {
+				// Strip any Composer 'dev-' prefix.
+				if ( 0 === strncmp( $version, 'dev-', 4 ) ) {
+					$version = substr( $version, 4 );
+				}
+				// Ignore/strip any relative suffixes.
+				if ( false !== ( $rel_pos = strpos( $version, '^' ) ) || false !== ( $rel_pos = strpos( $version, '~' ) ) ) {
+					$version = substr( $version, 0, $rel_pos );
+				}
+			}
+		}
+		// Default to master.
+		return '' === $version ? 'master' : $version;
 	}
 
 	/**


### PR DESCRIPTION
Closes #51 

Adds version arg to `check_git_package_name()` and passes to new function `get_raw_git_version()` that returns what should be used in the raw github request (with limited accuracy - eg suffixes such as `^0` are just stripped).

Needed to change an existing test to use the tag name `v0.1.0` instead of the version `0.1.0`.
  