### PR TITLE
Move `test-command` to `wp-cli-test` Github organization

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -394,7 +394,7 @@ Feature: Install WP-CLI packages
     When I try `wp package install wp-cli-test/test-command:0.1.0`
     Then STDERR should contain:
       """
-      Error: Couldn't download composer.json file from 'https://raw.githubusercontent.com/wp-cli-test/test-command/0.1.0/composer.json' (HTTP code 404).
+      Warning: Couldn't download composer.json file from 'https://raw.githubusercontent.com/wp-cli-test/test-command/0.1.0/composer.json' (HTTP code 404).
       """
     And STDOUT should be empty
 

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -453,7 +453,7 @@ Feature: Install WP-CLI packages
     When I run `wp package install wp-cli-test/test-command:dev-master#e1b60d6d2af5799231ce7c84f2089c16dd845be1`
     Then STDOUT should contain:
       """
-      Installing package wp-cli-test/test-command (dev-master#8e99bba16a65a3cde7405178a6badbb49349f554)
+      Installing package wp-cli-test/test-command (dev-master#e1b60d6d2af5799231ce7c84f2089c16dd845be1)
       """
     # This path is sometimes changed on Macs to prefix with /private
     And STDOUT should contain:

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -412,7 +412,7 @@ Feature: Install WP-CLI packages
   Scenario: Install a package from Git using a shortened package identifier and a specific commit hash
     Given an empty directory
 
-    When I run `wp package install wp-cli-test/test-command:dev-master#8e99bba16a65a3cde7405178a6badbb49349f554`
+    When I run `wp package install wp-cli-test/test-command:dev-master#e1b60d6d2af5799231ce7c84f2089c16dd845be1`
     Then STDOUT should contain:
       """
       Installing package wp-cli-test/test-command (dev-master#8e99bba16a65a3cde7405178a6badbb49349f554)

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -149,7 +149,14 @@ Feature: Install WP-CLI packages
     Then STDOUT should contain:
       """
       Installing package wp-cli/google-sitemap-generator-cli (dev-master)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Registering git@github.com:wp-cli/google-sitemap-generator-cli.git as a VCS repository...
       Using Composer to install the package...
       """
@@ -207,7 +214,14 @@ Feature: Install WP-CLI packages
     And STDOUT should contain:
       """
       Installing package capitalwpcli/examplecommand (dev-master)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Registering https://github.com/CapitalWPCLI/examplecommand.git as a VCS repository...
       Using Composer to install the package...
       """
@@ -273,7 +287,14 @@ Feature: Install WP-CLI packages
     Then STDOUT should contain:
       """
       Installing package wp-cli-test/test-command (dev-master)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Registering https://github.com/wp-cli-test/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
@@ -318,7 +339,14 @@ Feature: Install WP-CLI packages
     Then STDOUT should contain:
       """
       Installing package wp-cli-test/test-command (^0)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Registering https://github.com/wp-cli-test/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
@@ -371,7 +399,14 @@ Feature: Install WP-CLI packages
     Then STDOUT should contain:
       """
       Installing package wp-cli-test/test-command (v0.1.0)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Registering https://github.com/wp-cli-test/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
@@ -416,7 +451,14 @@ Feature: Install WP-CLI packages
     Then STDOUT should contain:
       """
       Installing package wp-cli-test/test-command (dev-master#8e99bba16a65a3cde7405178a6badbb49349f554)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Registering https://github.com/wp-cli-test/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
@@ -461,7 +503,14 @@ Feature: Install WP-CLI packages
     Then STDOUT should contain:
       """
       Installing package wp-cli-test/test-command (dev-custom-branch)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Registering https://github.com/wp-cli-test/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
@@ -507,7 +556,14 @@ Feature: Install WP-CLI packages
     And STDOUT should contain:
       """
       Installing package GeekPress/wp-rocket-cli (dev-master)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Using Composer to install the package...
       """
     And STDOUT should contain:
@@ -554,7 +610,14 @@ Feature: Install WP-CLI packages
     And STDOUT should contain:
       """
       Installing package GeekPress/wp-rocket-cli (dev-master)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Using Composer to install the package...
       """
     And STDOUT should contain:
@@ -603,7 +666,11 @@ Feature: Install WP-CLI packages
     Then STDOUT should contain:
       """
       Installing package wp-cli-test/version-composer-json-different (v1.0.0)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
       """
     And STDOUT should contain:
       """
@@ -624,7 +691,11 @@ Feature: Install WP-CLI packages
     Then STDOUT should contain:
       """
       Installing package wp-cli-test/version-composer-json-different (v1.0.1)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
       """
     And STDOUT should contain:
       """
@@ -649,7 +720,14 @@ Feature: Install WP-CLI packages
     Then STDOUT should contain:
       """
       Installing package wp-cli/google-sitemap-generator-cli (dev-master)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Registering {PACKAGE_PATH}local/wp-cli-google-sitemap-generator-cli as a path repository...
       Using Composer to install the package...
       """
@@ -698,7 +776,14 @@ Feature: Install WP-CLI packages
     And STDOUT should contain:
       """
       Installing package capitalwpcli/examplecommand (dev-master)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Registering https://github.com/CapitalWPCLI/examplecommand.git as a VCS repository...
       Using Composer to install the package...
       """
@@ -754,7 +839,14 @@ Feature: Install WP-CLI packages
     Then STDOUT should contain:
       """
       Installing package wp-cli/google-sitemap-generator-cli (dev-master)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Registering {PACKAGE_PATH}local/wp-cli-google-sitemap-generator-cli as a path repository...
       Using Composer to install the package...
       """
@@ -824,7 +916,14 @@ Feature: Install WP-CLI packages
     Then STDOUT should contain:
       """
       Installing package wp-cli/community-command (dev-master)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Registering {CURRENT_PATH}/path-command as a path repository...
       Using Composer to install the package...
       """
@@ -896,7 +995,14 @@ Feature: Install WP-CLI packages
     Then STDOUT should contain:
       """
       Installing package wp-cli/community-command (0.2.0-beta)
-      Updating {PACKAGE_PATH}composer.json to require the package...
+      """
+    # This path is sometimes changed on Macs to prefix with /private
+    And STDOUT should contain:
+      """
+      {PACKAGE_PATH}composer.json to require the package...
+      """
+    And STDOUT should contain:
+      """
       Registering {CURRENT_PATH}/path-command as a path repository...
       Using Composer to install the package...
       """

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -179,8 +179,11 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli/google-sitemap-generator-cli`
     Then STDOUT should contain:
       """
-      Removing require statement from {PACKAGE_PATH}composer.json
-      Removing repository details from {PACKAGE_PATH}composer.json
+      Removing require statement from
+      """
+    Then STDOUT should contain:
+      """
+      Removing repository details from
       """
     And the {PACKAGE_PATH}composer.json file should not contain:
       """
@@ -317,7 +320,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli-test/test-command`
     Then STDOUT should contain:
       """
-      Removing require statement from {PACKAGE_PATH}composer.json
+      Removing require statement from
       """
     And STDOUT should contain:
       """
@@ -369,7 +372,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli-test/test-command`
     Then STDOUT should contain:
       """
-      Removing require statement from {PACKAGE_PATH}composer.json
+      Removing require statement from
       """
     And STDOUT should contain:
       """
@@ -429,7 +432,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli-test/test-command`
     Then STDOUT should contain:
       """
-      Removing require statement from {PACKAGE_PATH}composer.json
+      Removing require statement from
       """
     And STDOUT should contain:
       """
@@ -481,7 +484,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli-test/test-command`
     Then STDOUT should contain:
       """
-      Removing require statement from {PACKAGE_PATH}composer.json
+      Removing require statement from
       """
     And STDOUT should contain:
       """
@@ -533,7 +536,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli-test/test-command`
     Then STDOUT should contain:
       """
-      Removing require statement from {PACKAGE_PATH}composer.json
+      Removing require statement from
       """
     And STDOUT should contain:
       """
@@ -593,7 +596,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall GeekPress/wp-rocket-cli`
     Then STDOUT should contain:
       """
-      Removing require statement from {PACKAGE_PATH}composer.json
+      Removing require statement from
       """
     And STDOUT should contain:
       """
@@ -647,7 +650,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall geekpress/wp-rocket-cli`
     Then STDOUT should contain:
       """
-      Removing require statement from {PACKAGE_PATH}composer.json
+      Removing require statement from
       """
     And STDOUT should contain:
       """
@@ -750,7 +753,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli/google-sitemap-generator-cli`
     Then STDOUT should contain:
       """
-      Removing require statement from {PACKAGE_PATH}composer.json
+      Removing require statement from
       """
     And STDOUT should contain:
       """
@@ -814,7 +817,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall capitalwpcli/examplecommand`
     Then STDOUT should contain:
       """
-      Removing require statement from {PACKAGE_PATH}composer.json
+      Removing require statement from
       """
     And STDOUT should contain:
       """
@@ -869,7 +872,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli/google-sitemap-generator-cli`
     Then STDOUT should contain:
       """
-      Removing require statement from {PACKAGE_PATH}composer.json
+      Removing require statement from
       """
     And STDOUT should contain:
       """
@@ -946,7 +949,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli/community-command`
     Then STDOUT should contain:
       """
-      Removing require statement from {PACKAGE_PATH}composer.json
+      Removing require statement from
       """
     And STDOUT should contain:
       """
@@ -1025,7 +1028,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli/community-command`
     Then STDOUT should contain:
       """
-      Removing require statement from {PACKAGE_PATH}composer.json
+      Removing require statement from
       """
     And STDOUT should contain:
       """

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -265,17 +265,17 @@ Feature: Install WP-CLI packages
       Success: Test Mixed Case Command Name
       """
 
-  # Current releases of schlessera/test-command are PHP 5.5 dependent.
+  # Current releases of wp-cli-test/test-command are PHP 5.5 dependent.
   @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier
     Given an empty directory
 
-    When I run `wp package install schlessera/test-command`
+    When I run `wp package install wp-cli-test/test-command`
     Then STDOUT should contain:
       """
-      Installing package schlessera/test-command (dev-master)
+      Installing package wp-cli-test/test-command (dev-master)
       Updating {PACKAGE_PATH}composer.json to require the package...
-      Registering https://github.com/schlessera/test-command.git as a VCS repository...
+      Registering https://github.com/wp-cli-test/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
     And STDOUT should contain:
@@ -285,8 +285,8 @@ Feature: Install WP-CLI packages
 
     When I run `wp package list --fields=name,version`
     Then STDOUT should be a table containing rows:
-      | name                    | version    |
-      | schlessera/test-command | dev-master |
+      | name                     | version    |
+      | wp-cli-test/test-command | dev-master |
 
     When I run `wp test-command`
     Then STDOUT should contain:
@@ -294,7 +294,7 @@ Feature: Install WP-CLI packages
       Success: Version E.
       """
 
-    When I run `wp package uninstall schlessera/test-command`
+    When I run `wp package uninstall wp-cli-test/test-command`
     Then STDOUT should contain:
       """
       Removing require statement from {PACKAGE_PATH}composer.json
@@ -307,20 +307,20 @@ Feature: Install WP-CLI packages
     When I run `wp package list --fields=name`
     Then STDOUT should not contain:
       """
-      schlessera/test-command
+      wp-cli-test/test-command
       """
 
-  # Current releases of schlessera/test-command are PHP 5.5 dependent.
+  # Current releases of wp-cli-test/test-command are PHP 5.5 dependent.
   @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier with a version requirement
     Given an empty directory
 
-    When I run `wp package install schlessera/test-command:^0`
+    When I run `wp package install wp-cli-test/test-command:^0`
     Then STDOUT should contain:
       """
-      Installing package schlessera/test-command (^0)
+      Installing package wp-cli-test/test-command (^0)
       Updating {PACKAGE_PATH}composer.json to require the package...
-      Registering https://github.com/schlessera/test-command.git as a VCS repository...
+      Registering https://github.com/wp-cli-test/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
     And STDOUT should contain:
@@ -330,8 +330,8 @@ Feature: Install WP-CLI packages
 
     When I run `wp package list --fields=name,version`
     Then STDOUT should be a table containing rows:
-      | name                    | version |
-      | schlessera/test-command | v0.2.0  |
+      | name                     | version |
+      | wp-cli-test/test-command | v0.2.0  |
 
     When I run `wp test-command`
     Then STDOUT should contain:
@@ -339,7 +339,7 @@ Feature: Install WP-CLI packages
       Success: Version C.
       """
 
-    When I run `wp package uninstall schlessera/test-command`
+    When I run `wp package uninstall wp-cli-test/test-command`
     Then STDOUT should contain:
       """
       Removing require statement from {PACKAGE_PATH}composer.json
@@ -352,20 +352,20 @@ Feature: Install WP-CLI packages
     When I run `wp package list --fields=name`
     Then STDOUT should not contain:
       """
-      schlessera/test-command
+      wp-cli-test/test-command
       """
 
-  # Current releases of schlessera/test-command are PHP 5.5 dependent.
+  # Current releases of wp-cli-test/test-command are PHP 5.5 dependent.
   @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier with a specific version
     Given an empty directory
 
-    When I run `wp package install schlessera/test-command:0.1.0`
+    When I run `wp package install wp-cli-test/test-command:0.1.0`
     Then STDOUT should contain:
       """
-      Installing package schlessera/test-command (0.1.0)
+      Installing package wp-cli-test/test-command (0.1.0)
       Updating {PACKAGE_PATH}composer.json to require the package...
-      Registering https://github.com/schlessera/test-command.git as a VCS repository...
+      Registering https://github.com/wp-cli-test/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
     And STDOUT should contain:
@@ -375,8 +375,8 @@ Feature: Install WP-CLI packages
 
     When I run `wp package list --fields=name,version`
     Then STDOUT should be a table containing rows:
-      | name                    | version |
-      | schlessera/test-command | v0.1.0  |
+      | name                     | version |
+      | wp-cli-test/test-command | v0.1.0  |
 
     When I run `wp test-command`
     Then STDOUT should contain:
@@ -384,7 +384,7 @@ Feature: Install WP-CLI packages
       Success: Version A.
       """
 
-    When I run `wp package uninstall schlessera/test-command`
+    When I run `wp package uninstall wp-cli-test/test-command`
     Then STDOUT should contain:
       """
       Removing require statement from {PACKAGE_PATH}composer.json
@@ -397,20 +397,20 @@ Feature: Install WP-CLI packages
     When I run `wp package list --fields=name`
     Then STDOUT should not contain:
       """
-      schlessera/test-command
+      wp-cli-test/test-command
       """
 
-  # Current releases of schlessera/test-command are PHP 5.5 dependent.
+  # Current releases of wp-cli-test/test-command are PHP 5.5 dependent.
   @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier and a specific commit hash
     Given an empty directory
 
-    When I run `wp package install schlessera/test-command:dev-master#8e99bba16a65a3cde7405178a6badbb49349f554`
+    When I run `wp package install wp-cli-test/test-command:dev-master#8e99bba16a65a3cde7405178a6badbb49349f554`
     Then STDOUT should contain:
       """
-      Installing package schlessera/test-command (dev-master#8e99bba16a65a3cde7405178a6badbb49349f554)
+      Installing package wp-cli-test/test-command (dev-master#8e99bba16a65a3cde7405178a6badbb49349f554)
       Updating {PACKAGE_PATH}composer.json to require the package...
-      Registering https://github.com/schlessera/test-command.git as a VCS repository...
+      Registering https://github.com/wp-cli-test/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
     And STDOUT should contain:
@@ -420,8 +420,8 @@ Feature: Install WP-CLI packages
 
     When I run `wp package list --fields=name,version`
     Then STDOUT should be a table containing rows:
-      | name                    | version    |
-      | schlessera/test-command | dev-master |
+      | name                     | version    |
+      | wp-cli-test/test-command | dev-master |
 
     When I run `wp test-command`
     Then STDOUT should contain:
@@ -429,7 +429,7 @@ Feature: Install WP-CLI packages
       Success: Version B.
       """
 
-    When I run `wp package uninstall schlessera/test-command`
+    When I run `wp package uninstall wp-cli-test/test-command`
     Then STDOUT should contain:
       """
       Removing require statement from {PACKAGE_PATH}composer.json
@@ -442,20 +442,20 @@ Feature: Install WP-CLI packages
     When I run `wp package list --fields=name`
     Then STDOUT should not contain:
       """
-      schlessera/test-command
+      wp-cli-test/test-command
       """
 
-  # Current releases of schlessera/test-command are PHP 5.5 dependent.
+  # Current releases of wp-cli-test/test-command are PHP 5.5 dependent.
   @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier and a branch
     Given an empty directory
 
-    When I run `wp package install schlessera/test-command:dev-custom-branch`
+    When I run `wp package install wp-cli-test/test-command:dev-custom-branch`
     Then STDOUT should contain:
       """
-      Installing package schlessera/test-command (dev-custom-branch)
+      Installing package wp-cli-test/test-command (dev-custom-branch)
       Updating {PACKAGE_PATH}composer.json to require the package...
-      Registering https://github.com/schlessera/test-command.git as a VCS repository...
+      Registering https://github.com/wp-cli-test/test-command.git as a VCS repository...
       Using Composer to install the package...
       """
     And STDOUT should contain:
@@ -465,8 +465,8 @@ Feature: Install WP-CLI packages
 
     When I run `wp package list --fields=name,version`
     Then STDOUT should be a table containing rows:
-      | name                    | version           |
-      | schlessera/test-command | dev-custom-branch |
+      | name                     | version           |
+      | wp-cli-test/test-command | dev-custom-branch |
 
     When I run `wp test-command`
     Then STDOUT should contain:
@@ -474,7 +474,7 @@ Feature: Install WP-CLI packages
       Success: Version D.
       """
 
-    When I run `wp package uninstall schlessera/test-command`
+    When I run `wp package uninstall wp-cli-test/test-command`
     Then STDOUT should contain:
       """
       Removing require statement from {PACKAGE_PATH}composer.json
@@ -487,7 +487,7 @@ Feature: Install WP-CLI packages
     When I run `wp package list --fields=name`
     Then STDOUT should not contain:
       """
-      schlessera/test-command
+      wp-cli-test/test-command
       """
 
   @github-api

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -265,8 +265,7 @@ Feature: Install WP-CLI packages
       Success: Test Mixed Case Command Name
       """
 
-  # Current releases of wp-cli-test/test-command are PHP 5.5 dependent.
-  @github-api @shortened @require-php-5.5
+  @github-api @shortened
   Scenario: Install a package from Git using a shortened package identifier
     Given an empty directory
 
@@ -310,7 +309,7 @@ Feature: Install WP-CLI packages
       wp-cli-test/test-command
       """
 
-  # Current releases of wp-cli-test/test-command are PHP 5.5 dependent.
+  # Older releases of wp-cli-test/test-command are PHP 5.5 dependent.
   @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier with a version requirement
     Given an empty directory
@@ -355,7 +354,7 @@ Feature: Install WP-CLI packages
       wp-cli-test/test-command
       """
 
-  # Current releases of wp-cli-test/test-command are PHP 5.5 dependent.
+  # Older releases of wp-cli-test/test-command are PHP 5.5 dependent.
   @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier with a specific version
     Given an empty directory
@@ -400,7 +399,7 @@ Feature: Install WP-CLI packages
       wp-cli-test/test-command
       """
 
-  # Current releases of wp-cli-test/test-command are PHP 5.5 dependent.
+  # Older releases of wp-cli-test/test-command are PHP 5.5 dependent.
   @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier and a specific commit hash
     Given an empty directory
@@ -445,7 +444,7 @@ Feature: Install WP-CLI packages
       wp-cli-test/test-command
       """
 
-  # Current releases of wp-cli-test/test-command are PHP 5.5 dependent.
+  # Older releases of wp-cli-test/test-command are PHP 5.5 dependent.
   @github-api @shortened @require-php-5.5
   Scenario: Install a package from Git using a shortened package identifier and a branch
     Given an empty directory

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -396,7 +396,6 @@ Feature: Install WP-CLI packages
       """
       Warning: Couldn't download composer.json file from 'https://raw.githubusercontent.com/wp-cli-test/test-command/0.1.0/composer.json' (HTTP code 404).
       """
-    And STDOUT should be empty
 
     When I run `wp package install wp-cli-test/test-command:v0.1.0`
     Then STDOUT should contain:


### PR DESCRIPTION
We should avoid having tests rely on outside/personal dependencies.