### PR TITLE
v1.0.11 prerelease: refresh test suite, require wp-cli ^1.5.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,21 +20,20 @@
         "psr-4": {
             "": "src/"
         },
-        "files": [
-            "package-command.php"
-        ]
+        "files": [ "package-command.php" ]
     },
     "require": {
-        "wp-cli/wp-cli": "*",
         "composer/composer": "^1.2.0"
     },
     "require-dev": {
-        "behat/behat": "~2.5"
+        "behat/behat": "~2.5",
+        "wp-cli/wp-cli": "^1.5"
     },
     "extra": {
         "branch-alias": {
             "dev-master": "1.x-dev"
         },
+        "bundled": true,
         "commands": [
             "package",
             "package browse",
@@ -42,7 +41,6 @@
             "package list",
             "package update",
             "package uninstall"
-        ],
-        "bundled": true
+        ]
     }
 }

--- a/features/bootstrap/utils.php
+++ b/features/bootstrap/utils.php
@@ -511,14 +511,15 @@ function mustache_render( $template_name, $data = array() ) {
  *
  * @param string  $message  Text to display before the progress bar.
  * @param integer $count    Total number of ticks to be performed.
+ * @param int     $interval Optional. The interval in milliseconds between updates. Default 100.
  * @return cli\progress\Bar|WP_CLI\NoOp
  */
-function make_progress_bar( $message, $count ) {
+function make_progress_bar( $message, $count, $interval = 100 ) {
 	if ( \cli\Shell::isPiped() ) {
 		return new \WP_CLI\NoOp;
 	}
 
-	return new \cli\progress\Bar( $message, $count );
+	return new \cli\progress\Bar( $message, $count, $interval );
 }
 
 function parse_url( $url ) {
@@ -769,6 +770,16 @@ function get_home_dir() {
  */
 function trailingslashit( $string ) {
 	return rtrim( $string, '/\\' ) . '/';
+}
+
+/**
+ * Convert Windows EOLs to *nix.
+ *
+ * @param string $str String to convert.
+ * @return string String with carriage return / newline pairs reduced to newlines.
+ */
+function normalize_eols( $str ) {
+	return str_replace( "\r\n", "\n", $str );
 }
 
 /**
@@ -1100,7 +1111,9 @@ function glob_brace( $pattern, $dummy_flags = null ) {
 function get_suggestion( $target, array $options, $threshold = 2 ) {
 
 	$suggestion_map = array(
+		'add' => 'create',
 		'check' => 'check-update',
+		'capability' => 'cap',
 		'clear' => 'flush',
 		'decrement' => 'decr',
 		'del' => 'delete',
@@ -1116,6 +1129,7 @@ function get_suggestion( $target, array $options, $threshold = 2 ) {
 		'regen' => 'regenerate',
 		'rep' => 'replace',
 		'repl' => 'replace',
+		'trash' => 'delete',
 		'v' => 'version',
 	);
 
@@ -1354,4 +1368,86 @@ function _proc_open_compat_win_env( $cmd, &$env ) {
 		}
 	}
 	return $cmd;
+}
+
+/**
+ * First half of escaping for LIKE special characters % and _ before preparing for MySQL.
+ *
+ * Use this only before wpdb::prepare() or esc_sql().  Reversing the order is very bad for security.
+ *
+ * Copied from core "wp-includes/wp-db.php". Avoids dependency on WP 4.4 wpdb.
+ *
+ * @access public
+ *
+ * @param string $text The raw text to be escaped. The input typed by the user should have no
+ *                     extra or deleted slashes.
+ * @return string Text in the form of a LIKE phrase. The output is not SQL safe. Call $wpdb::prepare()
+ *                or real_escape next.
+ */
+function esc_like( $text ) {
+	return addcslashes( $text, '_%\\' );
+}
+
+/**
+ * Escapes (backticks) MySQL identifiers (aka schema object names) - i.e. column names, table names, and database/index/alias/view etc names.
+ * See https://dev.mysql.com/doc/refman/5.5/en/identifiers.html
+ *
+ * @param string|array $idents A single identifier or an array of identifiers.
+ * @return string|array An escaped string if given a string, or an array of escaped strings if given an array of strings.
+ */
+function esc_sql_ident( $idents ) {
+	$backtick = function ( $v ) {
+		// Escape any backticks in the identifier by doubling.
+		return '`' . str_replace( '`', '``', $v ) . '`';
+	};
+	if ( is_string( $idents ) ) {
+		return $backtick( $idents );
+	}
+	return array_map( $backtick, $idents );
+}
+
+/**
+ * Check whether a given string is a valid JSON representation.
+ *
+ * @param string $argument       String to evaluate.
+ * @param bool   $ignore_scalars Optional. Whether to ignore scalar values.
+ *                               Defaults to true.
+ *
+ * @return bool Whether the provided string is a valid JSON representation.
+ */
+function is_json( $argument, $ignore_scalars = true ) {
+	if ( ! is_string( $argument ) || '' === $argument ) {
+		return false;
+	}
+
+	if ( $ignore_scalars && ! in_array( $argument[0], array( '{', '[' ), true ) ) {
+		return false;
+	}
+
+	json_decode( $argument, $assoc = true );
+
+	return json_last_error() === JSON_ERROR_NONE;
+}
+
+/**
+ * Parse known shell arrays included in the $assoc_args array.
+ *
+ * @param array $assoc_args      Associative array of arguments.
+ * @param array $array_arguments Array of argument keys that should receive an
+ *                               array through the shell.
+ *
+ * @return array
+ */
+function parse_shell_arrays( $assoc_args, $array_arguments ) {
+	if ( empty( $assoc_args ) || empty( $array_arguments ) ) {
+		return $assoc_args;
+	}
+
+	foreach ( $array_arguments as $key ) {
+		if ( array_key_exists( $key, $assoc_args ) && is_json( $assoc_args[ $key ] ) ) {
+			$assoc_args[ $key ] = json_decode( $assoc_args[ $key ], $assoc = true );
+		}
+	}
+
+	return $assoc_args;
 }

--- a/utils/behat-tags.php
+++ b/utils/behat-tags.php
@@ -31,17 +31,24 @@ function version_tags( $prefix, $current, $operator = '<' ) {
 	return $skip_tags;
 }
 
+$wp_version = getenv( 'WP_VERSION' );
 $wp_version_reqs = array();
-// Only apply @require-wp tags when WP_VERSION isn't 'latest' or 'nightly'
-// 'latest' and 'nightly' are expected to work with all features
-if ( ! in_array( getenv( 'WP_VERSION' ), array( 'latest', 'nightly', 'trunk' ), true ) ) {
-	$wp_version_reqs = version_tags( 'require-wp', getenv( 'WP_VERSION' ), '<' );
+// Only apply @require-wp tags when WP_VERSION isn't 'latest', 'nightly' or 'trunk'.
+// 'latest', 'nightly' and 'trunk' are expected to work with all features.
+if ( $wp_version && ! in_array( $wp_version, array( 'latest', 'nightly', 'trunk' ), true ) ) {
+	$wp_version_reqs = array_merge(
+		version_tags( 'require-wp', $wp_version, '<' ),
+		version_tags( 'less-than-wp', $wp_version, '>=' )
+	);
+} else {
+	// But make sure @less-than-wp tags always exist for those special cases. (Note: @less-than-wp-latest etc won't work and shouldn't be used).
+	$wp_version_reqs = array_merge( $wp_version_reqs, version_tags( 'less-than-wp', '9999', '>=' ) );
 }
 
 $skip_tags = array_merge(
 	$wp_version_reqs,
 	version_tags( 'require-php', PHP_VERSION, '<' ),
-	version_tags( 'less-than-php', PHP_VERSION, '>' )
+	version_tags( 'less-than-php', PHP_VERSION, '>=' ) // Note: this was '>' prior to WP-CLI 1.5.0 but the change is unlikely to cause BC issues as usually compared against major.minor only.
 );
 
 # Skip Github API tests if `GITHUB_TOKEN` not available because of rate limiting. See https://github.com/wp-cli/wp-cli/issues/1612


### PR DESCRIPTION
Refreshes test suite and normalizes composer.json, requiring `wp-cli/wp-cli` ^1.5.

1.0.11 pre-release changes for WP-CLI 1.5.0.