### PR TITLE
Fake v1 version for v2 framework for now

### DIFF
--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -855,7 +855,14 @@ class Package_Command extends WP_CLI_Command {
 	 */
 	private static function get_wp_cli_version_composer() {
 		preg_match( '#^[0-9\.]+(-(alpha|beta)[^-]{0,})?#', WP_CLI_VERSION, $matches );
-		return isset( $matches[0] ) ? $matches[0] : '';
+		$version = isset( $matches[0] ) ? $matches[0] : '';
+		if ( 0 === strpos( $version, '2' ) ) {
+			// Fake a v1.x.x version for v2.x.x framework for now, as the
+			// command package are not yet accepting v2.x.x to meet their
+			// dependency requirements.
+			$version = '1.99.99-alpha';
+		}
+		return $version;
 	}
 
 	/**


### PR DESCRIPTION
The package manager uses `WP_CLI_VERSION` to require the framework. Through the `VERSION` file, the framework now has the version `2.0.0-alpha` already. This causes package installs to fail, as all packages require `v1.x.x` framework as a dependency.

This PR intercepts v2.x versions of the framework in the package manager and fakes them to be versioned at `1.99.99-alpha`, so that it still works with existing packages.

This is a temporary measure. The correct solution is to adapt the packages so that they either work with both v1 & v2, or are known and accpeted to not work with v2 due to breaking changes.

Related https://github.com/wp-cli/scaffold-package-command/issues/167