### PR TITLE
Avoid using Composer CA bundle if in phar.

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -1009,7 +1009,8 @@ Feature: Install WP-CLI packages
       }
       """
 
-    When I run `{PHAR_PATH} package install path-command`
+    # Allow for composer/ca-bundle using `openssl_x509_parse()` which throws PHP warnings on old versions of PHP.
+    When I try `{PHAR_PATH} package install path-command`
     Then STDOUT should contain:
       """
       Success: Package installed.
@@ -1051,7 +1052,8 @@ Feature: Install WP-CLI packages
       }
       """
 
-    When I run `{PHAR_PATH} package install path-command`
+    # Allow for composer/ca-bundle using `openssl_x509_parse()` which throws PHP warnings on old versions of PHP.
+    When I try `{PHAR_PATH} package install path-command`
     Then STDOUT should contain:
       """
       Success: Package installed.


### PR DESCRIPTION
Fixes #72 

Adds method `avoid_composer_ca_bundle()` to use `SSL_CERT_FILE` env var to get Composer to use WP-CLI standard `Requests/Transport/cacert.pem` instead of default Composer CA bundle which isn't included in the phar.

Tested manually on Windows 10.