### PR TITLE
Handle unavailable composer.json on private repo (issue #76)

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -1083,14 +1083,13 @@ Feature: Install WP-CLI packages
 
     When I try `wp package install https://github.com/non-existent-git-user-asdfasdf/non-existent-git-repo-asdfasdf.git`
     Then the return code should be 1
-    And STDERR should be:
+    And STDERR should contain:
       """
-      Error: Couldn't download composer.json file from 'https://raw.githubusercontent.com/non-existent-git-user-asdfasdf/non-existent-git-repo-asdfasdf/master/composer.json' (HTTP code 404).
+      Warning: Couldn't download composer.json file from 'https://raw.githubusercontent.com/non-existent-git-user-asdfasdf/non-existent-git-repo-asdfasdf/master/composer.json' (HTTP code 404). Presuming package name is 'non-existent-git-repo-asdfasdf'.
       """
-    And STDOUT should be empty
 
     When I try `wp package install https://github.com/wp-cli-tests/private-repository.git`
-    Then STDOUT should contain:
+    Then STDERR should contain:
       """
       Warning: Couldn't download composer.json file from 'https://raw.githubusercontent.com/wp-cli-tests/private-repository/master/composer.json' (HTTP code 404). Presuming package name is 'private-repository'.
       """

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -1089,6 +1089,12 @@ Feature: Install WP-CLI packages
       """
     And STDOUT should be empty
 
+    When I try `wp package install https://github.com/wp-cli-tests/private-repository.git`
+    Then STDOUT should contain:
+      """
+      Warning: Couldn't download composer.json file from 'https://raw.githubusercontent.com/wp-cli-tests/private-repository/master/composer.json' (HTTP code 404). Presuming package name is 'private-repository'.
+      """
+
     When I try `wp package install non-existent-git-user-asdfasdf/non-existent-git-repo-asdfasdf`
     Then the return code should be 1
     And STDERR should be:

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -995,7 +995,8 @@ class Package_Command extends WP_CLI_Command {
 		$response = WP_CLI\Utils\http_request( 'GET', $raw_content_url, null /*data*/, $headers );
 		if ( 20 != substr( $response->status_code, 0, 2 ) ) {
 			// Could not get composer.json. Possibly private so warn and return best guess from input (always xxx/xxx).
-			$package_name = explode( '/', $package_name )[1];
+			$package_name = explode( '/', $package_name );
+			$package_name = $package_name[1];
 			WP_CLI::warning( sprintf( "Couldn't download composer.json file from '%s' (HTTP code %d). Presuming package name is '%s'.", $raw_content_url, $response->status_code, $package_name ) );
 			return $package_name;
 		}

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -994,7 +994,10 @@ class Package_Command extends WP_CLI_Command {
 
 		$response = WP_CLI\Utils\http_request( 'GET', $raw_content_url, null /*data*/, $headers );
 		if ( 20 != substr( $response->status_code, 0, 2 ) ) {
-			WP_CLI::error( sprintf( "Couldn't download composer.json file from '%s' (HTTP code %d).", $raw_content_url, $response->status_code ) );
+			// Could not get composer.json. Possibly private so warn and return best guess from input (always xxx/xxx).
+			$package_name = explode( '/', $package_name )[1];
+			WP_CLI::warning( sprintf( "Couldn't download composer.json file from '%s' (HTTP code %d). Presuming package name is '%s'.", $raw_content_url, $response->status_code, $package_name ) );
+			return $package_name;
 		}
 
 		// Convert composer.json JSON to Array.


### PR DESCRIPTION
- Warning, not Error, when composer.json cannot be retrieved
- Return best-guess $package_name