### PR TITLE
Add preliminary PHP 7.4 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 dist: trusty
 
 language: php
-php: 7.2
+php: 7.3
 
 notifications:
   email:
@@ -51,6 +51,9 @@ jobs:
         - composer phpcs
       env: BUILD=sniff
     - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest
+    - stage: test
       php: 7.3
       env: WP_VERSION=latest
     - stage: test
@@ -75,3 +78,7 @@ jobs:
       php: 5.4
       dist: precise
       env: WP_VERSION=5.1
+  allow_failures:
+    - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -621,7 +621,7 @@ class Package_Command extends WP_CLI_Command {
 
 			// Prevent DateTime error/warning when no timezone set.
 			// Note: The package is loaded before WordPress load, For environments that don't have set time in php.ini.
-			// phpcs:ignore WordPress.WP.TimezoneChange.timezone_change_date_default_timezone_set,WordPress.PHP.NoSilencedErrors.Discouraged
+			// phpcs:ignore WordPress.DateTime.RestrictedFunctions.timezone_change_date_default_timezone_set,WordPress.PHP.NoSilencedErrors.Discouraged
 			date_default_timezone_set( @date_default_timezone_get() );
 
 			$composer = Factory::create( new NullIO(), $composer_path );


### PR DESCRIPTION
The testing step for PHP 7.4 is still allowed to fail for now while we prepare the code base for the upcoming release.