### PR TITLE
Fix broken tests because of missing repo

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -49,7 +49,7 @@ Feature: Install WP-CLI packages
   Scenario: Install a package with 'wp-cli/wp-cli' as a dependency
     Given a WP install
 
-    When I run `wp package install sinebridge/wp-cli-about:v1.0.1`
+    When I run `wp package install typisttech/image-optimize-command:v0.3.1`
     Then STDOUT should contain:
       """
       Success: Package installed
@@ -59,10 +59,10 @@ Feature: Install WP-CLI packages
       requires wp-cli/wp-cli
       """
 
-    When I run `wp about`
+    When I run `wp help image-optimize`
     Then STDOUT should contain:
       """
-      Site Information
+      Optimize images.
       """
 
   @require-php-5.6

--- a/tests/test-composer-json.php
+++ b/tests/test-composer-json.php
@@ -180,6 +180,6 @@ class ComposerJsonTest extends PHPUnit_Framework_TestCase {
 	}
 
 	private function mac_safe_path( $path ) {
-		return preg_replace( '|^/private/var/|', '/var/', $path );
+		return preg_replace( '#^/private/(var|tmp)/#i', '/$1/', $path );
 	}
 }


### PR DESCRIPTION
The repo `sinebridge/wp-cli-about` is gone from GitHub. It was replaced with `typisttech/image-optimize-command`.