### PR TITLE
Replace missing test package

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -49,7 +49,7 @@ Feature: Install WP-CLI packages
   Scenario: Install a package with 'wp-cli/wp-cli' as a dependency
     Given a WP install
 
-    When I run `wp package install sinebridge/wp-cli-about:v1.0.1`
+    When I run `wp package install wp-cli-test/test-command:v0.2.0`
     Then STDOUT should contain:
       """
       Success: Package installed
@@ -59,10 +59,10 @@ Feature: Install WP-CLI packages
       requires wp-cli/wp-cli
       """
 
-    When I run `wp about`
+    When I run `wp test-command`
     Then STDOUT should contain:
       """
-      Site Information
+      Version C.
       """
 
   @require-php-5.6

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -46,6 +46,7 @@ Feature: Install WP-CLI packages
       "url": "http://wp-cli.org/package-index/"
       """
 
+  @require-php-5.6
   Scenario: Install a package with 'wp-cli/wp-cli' as a dependency
     Given a WP install
 

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -1223,7 +1223,7 @@ class Package_Command extends WP_CLI_Command {
 		];
 
 		register_shutdown_function(
-			function () use (
+			static function () use (
 				$json_path,
 				$composer_backup,
 				&$revert,
@@ -1234,14 +1234,15 @@ class Package_Command extends WP_CLI_Command {
 				$error_array
 			) {
 				if ( $revert ) {
-					if ( false === file_put_contents( $json_path, $composer_backup ) ) {
-						fwrite( STDERR, $revert_fail_msg );
-					} else {
+					if ( false !== file_put_contents( $json_path, $composer_backup ) ) {
 						fwrite( STDERR, $revert_msg );
+					} else {
+						fwrite( STDERR, $revert_fail_msg );
 					}
 				}
+
 				$error_array = error_get_last();
-				if ( false !== strpos( $error_array['message'], $memory_string ) ) {
+				if ( is_array( $error_array ) && false !== strpos( $error_array['message'], $memory_string ) ) {
 					fwrite( STDERR, $memory_msg );
 				}
 			}

--- a/tests/test-composer-json.php
+++ b/tests/test-composer-json.php
@@ -180,6 +180,6 @@ class ComposerJsonTest extends PHPUnit_Framework_TestCase {
 	}
 
 	private function mac_safe_path( $path ) {
-		return preg_replace( '|^/private/var/|', '/var/', $path );
+		return preg_replace( '#^/private/(var|tmp)/#i', '/$1/', $path );
 	}
 }


### PR DESCRIPTION
The package `sinebridge-wp-cli-about` was removed from GitHub. This PR replaces it with `wp-cli-test/test-command`, which is under our ownk control.