### PR TITLE
Fix Travis CI `sudo` warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+os: linux
 dist: trusty
 
 language: php

--- a/.travis.yml--
+++ b/.travis.yml--
@@ -1,0 +1,84 @@
+sudo: false
+dist: trusty
+
+language: php
+php: 7.3
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+branches:
+  only:
+    - master
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+env:
+  global:
+    - PATH="$TRAVIS_BUILD_DIR/vendor/bin:$PATH"
+    - WP_CLI_BIN_DIR="$TRAVIS_BUILD_DIR/vendor/bin"
+
+before_install:
+  - |
+    # Remove Xdebug for a huge performance increase:
+    if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
+      phpenv config-rm xdebug.ini
+    else
+      echo "xdebug.ini does not exist"
+    fi
+  - |
+    # Raise PHP memory limit to 2048MB
+    echo 'memory_limit = 2048M' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - composer validate
+
+install:
+  - composer install
+  - composer prepare-tests
+
+script:
+  - composer phpunit
+  - composer behat || composer behat-rerun
+
+jobs:
+  include:
+    - stage: sniff
+      script:
+        - composer lint
+        - composer phpcs
+      env: BUILD=sniff
+    - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest
+    - stage: test
+      php: 7.3
+      env: WP_VERSION=latest
+    - stage: test
+      php: 7.2
+      env: WP_VERSION=latest
+    - stage: test
+      php: 7.1
+      env: WP_VERSION=latest
+    - stage: test
+      php: 7.0
+      env: WP_VERSION=latest
+    - stage: test
+      php: 5.6
+      env: WP_VERSION=latest
+    - stage: test
+      php: 5.6
+      env: WP_VERSION=3.7.11
+    - stage: test
+      php: 5.6
+      env: WP_VERSION=trunk
+    - stage: test
+      php: 5.4
+      dist: precise
+      env: WP_VERSION=5.1
+  allow_failures:
+    - stage: test
+      php: 7.4snapshot
+      env: WP_VERSION=latest

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "ext-json": "*",
         "composer/composer": ">=1.2.0 <1.7.0 || ^1.7.1",
-        "wp-cli/wp-cli": "^2.1"
+        "wp-cli/wp-cli": "dev-master"
     },
     "require-dev": {
         "wp-cli/scaffold-command": "^1 || ^2",


### PR DESCRIPTION
Travis currently shows a warning that the configuration option `sudo` has been deprecated.

As there's another information (not a warning yet) that the configuration argument `os` is missing and defaults to `linux`, this PR replace `sudo: false` with `os: linux`.