### PR TITLE
Make the package manager compatible with Composer v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "wp-cli/scaffold-command": "^1 || ^2",
-        "wp-cli/wp-cli-tests": "^2.1"
+        "wp-cli/wp-cli-tests": "^2.1.16"
     },
     "config": {
         "process-timeout": 7200,

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "ext-json": "*",
-        "composer/composer": ">=1.2.0 <1.7.0 || ^1.7.1",
+        "composer/composer": ">=1.2.0 <1.7.0 || ^1.7.1 || ^2.0.0",
         "wp-cli/wp-cli": "dev-master"
     },
     "require-dev": {

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -259,14 +259,7 @@ Feature: Install WP-CLI packages
       """
       Success: Package installed.
       """
-    And the {PACKAGE_PATH}composer.json file should contain:
-      """
-      "gitlost/TestMixedCaseCommand"
-      """
-    And the {PACKAGE_PATH}composer.json file should not contain:
-      """
-      mixed
-      """
+    And the contents of the {PACKAGE_PATH}composer.json file should match /\"gitlost\/(?:TestMixedCaseCommand|testmixedcasecommand)\"/
 
     When I run `wp package list --fields=name`
     Then STDOUT should be a table containing rows:
@@ -548,10 +541,7 @@ Feature: Install WP-CLI packages
     # Install and uninstall with case-sensitive name
     When I run `wp package install GeekPress/wp-rocket-cli`
     Then STDERR should be empty
-    And STDOUT should contain:
-      """
-      Installing package GeekPress/wp-rocket-cli (dev-master)
-      """
+    And STDOUT should match /Installing package (?:GeekPress|geekpress)\/wp-rocket-cli \(dev-master\)/
     # This path is sometimes changed on Macs to prefix with /private
     And STDOUT should contain:
       """
@@ -565,14 +555,7 @@ Feature: Install WP-CLI packages
       """
       Success: Package installed.
       """
-    And the {PACKAGE_PATH}composer.json file should contain:
-      """
-      GeekPress/wp-rocket-cli
-      """
-    And the {PACKAGE_PATH}composer.json file should not contain:
-      """
-      geek
-      """
+    And the contents of the {PACKAGE_PATH}composer.json file should match /("?:GeekPress|geekpress)\/wp-rocket-cli"/
 
     When I run `wp package list --fields=name`
     Then STDOUT should be a table containing rows:
@@ -602,10 +585,7 @@ Feature: Install WP-CLI packages
     # Install with lowercase name (for BC - no warning) and uninstall with lowercase name (for BC and convenience)
     When I run `wp package install geekpress/wp-rocket-cli`
     Then STDERR should be empty
-    And STDOUT should contain:
-      """
-      Installing package GeekPress/wp-rocket-cli (dev-master)
-      """
+    And STDOUT should match /Installing package (?:GeekPress|geekpress)\/wp-rocket-cli \(dev-master\)/
     # This path is sometimes changed on Macs to prefix with /private
     And STDOUT should contain:
       """
@@ -619,14 +599,7 @@ Feature: Install WP-CLI packages
       """
       Success: Package installed.
       """
-    And the {PACKAGE_PATH}composer.json file should contain:
-      """
-      GeekPress/wp-rocket-cli
-      """
-    And the {PACKAGE_PATH}composer.json file should not contain:
-      """
-      geek
-      """
+    And the contents of the {PACKAGE_PATH}composer.json file should match /("?:GeekPress|geekpress)\/wp-rocket-cli"/
 
     When I run `wp package list --fields=name`
     Then STDOUT should be a table containing rows:

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -71,10 +71,6 @@ Feature: Install WP-CLI packages
     Given an empty directory
 
     When I run `wp package install trendwerk/faker`
-    Then STDOUT should contain:
-      """
-      Warning: trendwerk/faker dev-master requires nelmio/alice
-      """
     And STDOUT should contain:
       """
       Success: Package installed

--- a/features/package-update.feature
+++ b/features/package-update.feature
@@ -51,10 +51,7 @@ Feature: Update WP-CLI packages
       """
 
     When I run `wp package update`
-    Then STDOUT should contain:
-      """
-      Nothing to install or update
-      """
+    Then STDOUT should match /Nothing to install(?: or update|, update or remove)/
     And STDOUT should contain:
       """
       Success: Packages updated.
@@ -88,10 +85,7 @@ Feature: Update WP-CLI packages
       """
       Success: Packages updated.
       """
-    And STDOUT should not contain:
-      """
-      Nothing to install or update
-      """
+    And STDOUT should not match /Nothing to install(?: or update|, update or remove)/
 
     When I run `wp package list --fields=name,update`
     Then STDOUT should be a table containing rows:
@@ -99,10 +93,7 @@ Feature: Update WP-CLI packages
       | wp-cli-test/updateable-package | none    |
 
     When I run `wp package update`
-    Then STDOUT should contain:
-      """
-      Nothing to install or update
-      """
+    Then STDOUT should match /Nothing to install(?: or update|, update or remove)/
     And STDOUT should contain:
       """
       Success: Packages updated.

--- a/features/package.feature
+++ b/features/package.feature
@@ -59,7 +59,7 @@ Feature: Manage WP-CLI packages
 
   Scenario: Revert the WP-CLI packages composer.json when fail to install/uninstall a package due to memory limit
     Given an empty directory
-    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M -ddisable_functions=ini_set} package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} package install danielbachhuber/wp-cli-reset-post-date-command`
     Then the return code should not be 0
     And STDERR should contain:
       """
@@ -72,7 +72,7 @@ Feature: Manage WP-CLI packages
       Success: Package installed.
       """
 
-    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M -ddisable_functions=ini_set} package uninstall danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} package uninstall danielbachhuber/wp-cli-reset-post-date-command`
     Then the return code should not be 0
     And STDERR should contain:
       """
@@ -84,7 +84,7 @@ Feature: Manage WP-CLI packages
     Then the {RUN_DIR}/mypackages/composer.json file should exist
     And save the {RUN_DIR}/mypackages/composer.json file as {MYPACKAGES_COMPOSER_JSON}
 
-    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages {INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=32M -ddisable_functions=ini_set} package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages {INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} package install danielbachhuber/wp-cli-reset-post-date-command`
     Then the return code should not be 0
     And STDERR should contain:
       """

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -318,6 +318,12 @@ class Package_Command extends WP_CLI_Command {
 			}
 		}
 
+		if ( $this->is_composer_v2() ) {
+			$package_name = function_exists( 'mb_strtolower' )
+				? mb_strtolower( $package_name )
+				: strtolower( $package_name );
+		}
+
 		WP_CLI::log( sprintf( 'Installing package %s (%s)', $package_name, $version ) );
 
 		// Read the WP-CLI packages composer.json and do some initial error checking.
@@ -834,7 +840,9 @@ class Package_Command extends WP_CLI_Command {
 			if ( in_array( $package->getPrettyName(), $installed_package_keys, true ) ) {
 				$installed_packages[] = $package;
 			} elseif ( false !== $idx ) { // Legacy incorrect name check.
-				WP_CLI::warning( sprintf( "Found package '%s' misnamed '%s' in '%s'.", $package->getPrettyName(), $installed_package_keys[ $idx ], $this->get_composer_json_path() ) );
+				if ( ! $this->is_composer_v2() ) {
+					WP_CLI::warning( sprintf( "Found package '%s' misnamed '%s' in '%s'.", $package->getPrettyName(), $installed_package_keys[ $idx ], $this->get_composer_json_path() ) );
+				}
 				$installed_packages[] = $package;
 			}
 		}

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -4,6 +4,7 @@ use Composer\Composer;
 use Composer\Config;
 use Composer\Config\JsonConfigSource;
 use Composer\DependencyResolver\Pool;
+use Composer\DependencyResolver\Request;
 use Composer\EventDispatcher\Event;
 use Composer\Factory;
 use Composer\IO\NullIO;
@@ -19,6 +20,7 @@ use Composer\Repository\CompositeRepository;
 use Composer\Repository\ComposerRepository;
 use Composer\Repository\RepositoryManager;
 use Composer\Util\Filesystem;
+use Composer\Util\HttpDownloader;
 use WP_CLI\ComposerIO;
 use WP_CLI\Extractor;
 use WP_CLI\Utils;
@@ -81,7 +83,7 @@ class Package_Command extends WP_CLI_Command {
 	const PACKAGE_INDEX_URL = 'https://wp-cli.org/package-index/';
 	const SSL_CERTIFICATE   = '/rmccue/requests/library/Requests/Transport/cacert.pem';
 
-	private $pool = false;
+	private $version_selector = false;
 
 	/**
 	 * Default author data used while creating default WP-CLI packages composer.json.
@@ -676,8 +678,14 @@ class Package_Command extends WP_CLI_Command {
 			$config->merge( $config_args );
 			$config->setConfigSource( new JsonConfigSource( $this->get_composer_json() ) );
 
+			$io = new NullIO();
 			try {
-				$package_index = new ComposerRepository( [ 'url' => self::PACKAGE_INDEX_URL ], new NullIO(), $config );
+				if ( $this->is_composer_v2() ) {
+					$http_downloader = new HttpDownloader( $io, $config );
+					$package_index   = new ComposerRepository( [ 'url' => self::PACKAGE_INDEX_URL ], $io, $config, $http_downloader );
+				} else {
+					$package_index = new ComposerRepository( [ 'url' => self::PACKAGE_INDEX_URL ], $io, $config );
+				}
 			} catch ( Exception $e ) {
 				WP_CLI::error( $e->getMessage() );
 			}
@@ -995,9 +1003,9 @@ class Package_Command extends WP_CLI_Command {
 	 * @return PackageInterface|null
 	 */
 	private function find_latest_package( PackageInterface $package, Composer $composer, $php_version, $minor_only = false ) {
-		// find the latest version allowed in this pool
+		// Find the latest version allowed in this pool/repository set.
 		$name             = $package->getPrettyName();
-		$version_selector = new VersionSelector( $this->get_pool( $composer ) );
+		$version_selector = $this->get_version_selector( $composer );
 		$stability        = $composer->getPackage()->getMinimumStability();
 		$flags            = $composer->getPackage()->getStabilityFlags();
 		if ( isset( $flags[ $name ] ) ) {
@@ -1014,15 +1022,31 @@ class Package_Command extends WP_CLI_Command {
 		if ( null === $target_version && $minor_only ) {
 			$target_version = '^' . $package->getVersion();
 		}
+
+		if ( $this->is_composer_v2() ) {
+			return $version_selector->findBestCandidate( $name, $target_version, $best_stability );
+		}
+
 		return $version_selector->findBestCandidate( $name, $target_version, $php_version, $best_stability );
 	}
 
-	private function get_pool( Composer $composer ) {
-		if ( ! $this->pool ) {
-			$this->pool = new Pool( $composer->getPackage()->getMinimumStability(), $composer->getPackage()->getStabilityFlags() );
-			$this->pool->addRepository( new CompositeRepository( $composer->getRepositoryManager()->getRepositories() ) );
+	private function get_version_selector( Composer $composer ) {
+		if ( ! $this->version_selector ) {
+			if ( $this->is_composer_v2() ) {
+				$repository_set = new Repository\RepositorySet(
+					$composer->getPackage()->getMinimumStability(),
+					$composer->getPackage()->getStabilityFlags()
+				);
+				$repository_set->addRepository( new CompositeRepository( $composer->getRepositoryManager()->getRepositories() ) );
+				$this->version_selector = new VersionSelector( $repository_set );
+			} else {
+				$pool = new Pool( $composer->getPackage()->getMinimumStability(), $composer->getPackage()->getStabilityFlags() );
+				$pool->addRepository( new CompositeRepository( $composer->getRepositoryManager()->getRepositories() ) );
+				$this->version_selector = new VersionSelector( $pool );
+			}
 		}
-		return $this->pool;
+
+		return $this->version_selector;
 	}
 
 	/**
@@ -1316,5 +1340,14 @@ class Package_Command extends WP_CLI_Command {
 				}
 			}
 		);
+	}
+
+	/**
+	 * Check whether we are dealing with Composer version 2.0.0+.
+	 *
+	 * @return bool
+	 */
+	private function is_composer_v2() {
+		return version_compare( Composer::getVersion(), '2.0.0', '>=' );
 	}
 }


### PR DESCRIPTION
The package manager is powered by an embedded version of Composer. This PR makes sure the new Composer v2 can be embedded without issues as well.