### PR TITLE
Add `--insecure` flag to `package install` command

### DIFF
--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -382,6 +382,9 @@ class Package_Command extends WP_CLI_Command {
 		} catch ( Exception $e ) {
 			WP_CLI::warning( $e->getMessage() );
 		}
+
+		// TODO: The --insecure flag should cause another Composer run with verify disabled.
+
 		WP_CLI::log( '---' );
 
 		if ( 0 === $res ) {
@@ -515,6 +518,8 @@ class Package_Command extends WP_CLI_Command {
 			WP_CLI::warning( $e->getMessage() );
 		}
 		WP_CLI::log( '---' );
+
+		// TODO: The --insecure (to be added here) flag should cause another Composer run with verify disabled.
 
 		if ( 0 === $res ) {
 			WP_CLI::success( 'Packages updated.' );


### PR DESCRIPTION
The PR https://github.com/wp-cli/wp-cli/pull/5523 changes the default behavior for `Utils\http_request()` so that it does not automatically retry a remote request that failed its TLS handshake by skipping certificate validation.

This PR adds the `--insecure` flag to the following commands to explicitly switch back to the previous behavior:

- `package install`