### PR TITLE
Fetch default branch for GitHub packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,10 @@
     },
     "config": {
         "process-timeout": 7200,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -96,7 +96,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall yoast/wp-cli-faker`
     Then STDOUT should contain:
       """
-      Removing require statement
+      Removing require statement for package 'yoast/wp-cli-faker' from
       """
     And STDOUT should contain:
       """
@@ -176,7 +176,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli/google-sitemap-generator-cli`
     Then STDOUT should contain:
       """
-      Removing require statement from
+      Removing require statement for package 'wp-cli/google-sitemap-generator-cli' from
       """
     Then STDOUT should contain:
       """
@@ -310,7 +310,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli-test/github-test-command`
     Then STDOUT should contain:
       """
-      Removing require statement from
+      Removing require statement for package 'wp-cli-test/github-test-command' from
       """
     And STDOUT should contain:
       """
@@ -361,7 +361,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli-test/github-test-command`
     Then STDOUT should contain:
       """
-      Removing require statement from
+      Removing require statement for package 'wp-cli-test/github-test-command' from
       """
     And STDOUT should contain:
       """
@@ -419,7 +419,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli-test/github-test-command`
     Then STDOUT should contain:
       """
-      Removing require statement from
+      Removing require statement for package 'wp-cli-test/github-test-command' from
       """
     And STDOUT should contain:
       """
@@ -470,7 +470,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli-test/github-test-command`
     Then STDOUT should contain:
       """
-      Removing require statement from
+      Removing require statement for package 'wp-cli-test/github-test-command' from
       """
     And STDOUT should contain:
       """
@@ -521,7 +521,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli-test/github-test-command`
     Then STDOUT should contain:
       """
-      Removing require statement from
+      Removing require statement for package 'wp-cli-test/github-test-command' from
       """
     And STDOUT should contain:
       """
@@ -725,7 +725,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli/google-sitemap-generator-cli`
     Then STDOUT should contain:
       """
-      Removing require statement from
+      Removing require statement for package 'wp-cli/google-sitemap-generator-cli' from
       """
     And STDOUT should contain:
       """
@@ -789,7 +789,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall capitalwpcli/examplecommand`
     Then STDOUT should contain:
       """
-      Removing require statement from
+      Removing require statement for package 'capitalwpcli/examplecommand' from
       """
     And STDOUT should contain:
       """
@@ -844,7 +844,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli/google-sitemap-generator-cli`
     Then STDOUT should contain:
       """
-      Removing require statement from
+      Removing require statement for package 'wp-cli/google-sitemap-generator-cli' from
       """
     And STDOUT should contain:
       """
@@ -932,7 +932,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli/community-command`
     Then STDOUT should contain:
       """
-      Removing require statement from
+      Removing require statement for package 'wp-cli/community-command' from
       """
     And STDOUT should contain:
       """
@@ -1011,7 +1011,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall wp-cli/community-command`
     Then STDOUT should contain:
       """
-      Removing require statement from
+      Removing require statement for package 'wp-cli/community-command' from
       """
     And STDOUT should contain:
       """

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -571,14 +571,18 @@ Feature: Install WP-CLI packages
       wp rocket
       """
 
-    When I run `wp package uninstall GeekPress/wp-rocket-cli`
+    When I try `wp package uninstall GeekPress/wp-rocket-cli`
     Then STDOUT should contain:
       """
-      Removing require statement from
+      Removing require statement for package 'wp-media/wp-rocket-cli' from
       """
     And STDOUT should contain:
       """
       Success: Uninstalled package.
+      """
+    And STDERR should contain:
+      """
+      Warning: Package name mismatch...Updating from git name 'GeekPress/wp-rocket-cli' to composer.json name 'wp-media/wp-rocket-cli'.
       """
     And the {PACKAGE_PATH}composer.json file should not contain:
       """
@@ -607,7 +611,7 @@ Feature: Install WP-CLI packages
     When I run `wp package list --fields=name`
     Then STDOUT should be a table containing rows:
       | name                    |
-      | GeekPress/wp-rocket-cli |
+      | geekpress/wp-rocket-cli |
 
     When I run `wp help rocket`
     Then STDOUT should contain:
@@ -618,7 +622,7 @@ Feature: Install WP-CLI packages
     When I run `wp package uninstall geekpress/wp-rocket-cli`
     Then STDOUT should contain:
       """
-      Removing require statement from
+      Removing require statement for package 'geekpress/wp-rocket-cli' from
       """
     And STDOUT should contain:
       """

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -137,7 +137,7 @@ Feature: Install WP-CLI packages
       """
 
     When I try `wp package install git@github.com:wp-cli.git`
-    Then STDERR should be:
+    Then STDERR should contain:
       """
       Error: Couldn't parse package name from expected path '<name>/<package>'.
       """

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -539,9 +539,12 @@ Feature: Install WP-CLI packages
     Given an empty directory
 
     # Install and uninstall with case-sensitive name
-    When I run `wp package install GeekPress/wp-rocket-cli`
-    Then STDERR should be empty
-    And STDOUT should match /Installing package (?:GeekPress|geekpress)\/wp-rocket-cli \(dev-master\)/
+    When I try `wp package install GeekPress/wp-rocket-cli`
+    Then STDERR should contain:
+      """
+      Warning: Package name mismatch...Updating from git name 'GeekPress/wp-rocket-cli' to composer.json name 'wp-media/wp-rocket-cli'.
+      """
+    And STDOUT should match /Installing package wp-media\/wp-rocket-cli \(dev-trunk\)/
     # This path is sometimes changed on Macs to prefix with /private
     And STDOUT should contain:
       """
@@ -555,12 +558,12 @@ Feature: Install WP-CLI packages
       """
       Success: Package installed.
       """
-    And the contents of the {PACKAGE_PATH}composer.json file should match /("?:GeekPress|geekpress)\/wp-rocket-cli"/
+    And the contents of the {PACKAGE_PATH}composer.json file should match /"wp-media\/wp-rocket-cli"/
 
     When I run `wp package list --fields=name`
     Then STDOUT should be a table containing rows:
-      | name                    |
-      | GeekPress/wp-rocket-cli |
+      | name                   |
+      | wp-media/wp-rocket-cli |
 
     When I run `wp help rocket`
     Then STDOUT should contain:

--- a/features/package.feature
+++ b/features/package.feature
@@ -6,16 +6,20 @@ Feature: Manage WP-CLI packages
     When I run `wp package browse`
     Then STDOUT should contain:
       """
-      danielbachhuber/wp-cli-reset-post-date-command
+      runcommand/hook
       """
 
-    When I run `wp package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I run `wp package install runcommand/hook`
     Then STDERR should be empty
 
-    When I run `wp help reset-post-date`
+    When I run `wp help hook`
     Then STDERR should be empty
+    And STDOUT should contain:
+      """
+      List callbacks registered to a given action or filter.
+      """
 
-    When I try `wp --skip-packages --debug help reset-post-date`
+    When I try `wp --skip-packages --debug help hook`
     Then STDERR should contain:
       """
       Debug (bootstrap): Skipped loading packages.
@@ -28,16 +32,16 @@ Feature: Manage WP-CLI packages
     When I run `wp package list`
     Then STDOUT should contain:
       """
-      danielbachhuber/wp-cli-reset-post-date-command
+      runcommand/hook
       """
 
-    When I run `wp package uninstall danielbachhuber/wp-cli-reset-post-date-command`
+    When I run `wp package uninstall runcommand/hook`
     Then STDERR should be empty
 
     When I run `wp package list`
     Then STDOUT should not contain:
       """
-      danielbachhuber/wp-cli-reset-post-date-command
+      runcommand/hook
       """
 
   Scenario: Run package commands early, before any bad code can break them
@@ -60,20 +64,20 @@ Feature: Manage WP-CLI packages
   @require-php-7.2 @broken
   Scenario: Revert the WP-CLI packages composer.json when fail to install/uninstall a package due to memory limit
     Given an empty directory
-    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} package install runcommand/hook`
     Then the return code should not be 0
     And STDERR should contain:
       """
       Reverted composer.json.
       """
 
-    When I run `wp package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I run `wp package install runcommand/hook`
     Then STDOUT should contain:
       """
       Success: Package installed.
       """
 
-    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} package uninstall danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `{INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} package uninstall runcommand/hook`
     Then the return code should not be 0
     And STDERR should contain:
       """
@@ -85,7 +89,7 @@ Feature: Manage WP-CLI packages
     Then the {RUN_DIR}/mypackages/composer.json file should exist
     And save the {RUN_DIR}/mypackages/composer.json file as {MYPACKAGES_COMPOSER_JSON}
 
-    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages {INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/mypackages {INVOKE_WP_CLI_WITH_PHP_ARGS--dmemory_limit=10M -ddisable_functions=ini_set} package install runcommand/hook`
     Then the return code should not be 0
     And STDERR should contain:
       """
@@ -118,7 +122,7 @@ Feature: Manage WP-CLI packages
       """
     And STDOUT should be empty
 
-    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/packages-bad-json wp package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/packages-bad-json wp package install runcommand/hook`
     Then the return code should be 1
     And STDERR should contain:
       """
@@ -162,7 +166,7 @@ Feature: Manage WP-CLI packages
       """
     And save the {RUN_DIR}/packages-no-such-package/composer.json file as {NO_SUCH_PACKAGE_COMPOSER_JSON}
 
-    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/packages-no-such-package wp package install danielbachhuber/wp-cli-reset-post-date-command`
+    When I try `WP_CLI_PACKAGES_DIR={RUN_DIR}/packages-no-such-package wp package install runcommand/hook`
     Then the return code should be 1
     And STDERR should contain:
       """

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -564,7 +564,7 @@ class Package_Command extends WP_CLI_Command {
 			if ( false === $package_name ) {
 				WP_CLI::error( 'Package not installed.' );
 			}
-			$matches      = [];
+			$matches = [];
 			if ( preg_match( '#^https://github.com/(?<repo_name>.*?).git$#', $package_name, $matches ) ) {
 				$package_name = $matches['repo_name'];
 			}
@@ -1090,9 +1090,9 @@ class Package_Command extends WP_CLI_Command {
 	 *                             to false.
 	 */
 	private function check_github_package_name( $package_name, $version = '', $insecure = false ) {
-		$github_token    = getenv( 'GITHUB_TOKEN' ); // Use GITHUB_TOKEN if available to avoid authorization failures or rate-limiting.
-		$headers         = $github_token ? [ 'Authorization' => 'token ' . $github_token ] : [];
-		$options         = [ 'insecure' => $insecure ];
+		$github_token = getenv( 'GITHUB_TOKEN' ); // Use GITHUB_TOKEN if available to avoid authorization failures or rate-limiting.
+		$headers      = $github_token ? [ 'Authorization' => 'token ' . $github_token ] : [];
+		$options      = [ 'insecure' => $insecure ];
 
 		// Generate raw git URL of composer.json file.
 		$raw_content_url = "https://raw.githubusercontent.com/{$package_name}/{$this->get_raw_git_version( $version )}/composer.json";
@@ -1397,14 +1397,13 @@ class Package_Command extends WP_CLI_Command {
 	 *                             to false.
 	 * @return string Default branch, or 'master' if it could not be retrieved.
 	 */
-	private function get_github_default_branch( $package_name, $insecure = false )
-	{
-		$github_token    = getenv( 'GITHUB_TOKEN' ); // Use GITHUB_TOKEN if available to avoid authorization failures or rate-limiting.
-		$headers         = $github_token ? [ 'Authorization' => 'token ' . $github_token ] : [];
-		$options         = [ 'insecure' => $insecure ];
+	private function get_github_default_branch( $package_name, $insecure = false ) {
+		$github_token = getenv( 'GITHUB_TOKEN' ); // Use GITHUB_TOKEN if available to avoid authorization failures or rate-limiting.
+		$headers      = $github_token ? [ 'Authorization' => 'token ' . $github_token ] : [];
+		$options      = [ 'insecure' => $insecure ];
 
 		$github_api_repo_url = "https://api.github.com/repos/{$package_name}";
-		$response = Utils\http_request( 'GET', $github_api_repo_url, null /*data*/, $headers, $options );
+		$response            = Utils\http_request( 'GET', $github_api_repo_url, null /*data*/, $headers, $options );
 		if ( 20 !== (int) substr( $response->status_code, 0, 2 ) ) {
 			WP_CLI::warning(
 				sprintf(

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -1405,6 +1405,11 @@ class Package_Command extends WP_CLI_Command {
 		$headers      = $github_token ? [ 'Authorization' => 'token ' . $github_token ] : [];
 		$options      = [ 'insecure' => $insecure ];
 
+		$matches = [];
+		if ( preg_match( '#^(?:https?://github.com/|git@github.com:)(?<repo_name>.*?).git$#', $package_name, $matches ) ) {
+			$package_name = $matches['repo_name'];
+		}
+
 		$github_api_repo_url = "https://api.github.com/repos/{$package_name}";
 		$response            = Utils\http_request( 'GET', $github_api_repo_url, null /*data*/, $headers, $options );
 		if ( 20 !== (int) substr( $response->status_code, 0, 2 ) ) {

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -220,13 +220,12 @@ class Package_Command extends WP_CLI_Command {
 		$dir_package = false;
 		$version     = '';
 		if ( $this->is_git_repository( $package_name ) ) {
+			if ( '' === $version ) {
+				$version = "dev-{$this->get_github_default_branch( $package_name, $insecure )}";
+			}
 			$git_package = $package_name;
-			preg_match( '#([^:\/]+\/[^\/]+)\.git#', $package_name, $matches );
-			if ( ! empty( $matches[1] ) ) {
-				if ( '' === $version ) {
-					$version = "dev-{$this->get_github_default_branch( $package_name, $insecure )}";
-				}
-
+			$matches     = [];
+			if ( preg_match( '#([^:\/]+\/[^\/]+)\.git#', $package_name, $matches ) ) {
 				$package_name = $this->check_git_package_name( $matches[1], $package_name, $version, $insecure );
 			} else {
 				WP_CLI::error( "Couldn't parse package name from expected path '<name>/<package>'." );
@@ -316,6 +315,10 @@ class Package_Command extends WP_CLI_Command {
 			$package_name = function_exists( 'mb_strtolower' )
 				? mb_strtolower( $package_name )
 				: strtolower( $package_name );
+		}
+
+		if ( '' === $version ) {
+			$version = 'dev-master';
 		}
 
 		WP_CLI::log( sprintf( 'Installing package %s (%s)', $package_name, $version ) );


### PR DESCRIPTION
This PR adds logic to the `wp package install` command so that it tries to retrieve the default branch of a GitHub repository if no version was provided, instead of using the hard-coded `master` branch as a default.