### PR TITLE
Use auth for GitLab private repos, and fix GitLab failover behavior

### DIFF
--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -849,6 +849,16 @@ class Package_Command extends WP_CLI_Command {
 			return $url;
 		}
 
+		// Fall back to GitLab URL if we had no match yet.
+		$url          = "https://gitlab.com/{$package_name}.git";
+		$gitlab_token = getenv( 'GITLAB_TOKEN' ); // Use GITLAB_TOKEN if available to avoid authorization failures or rate-limiting.
+		$headers      = $github_token ? [ 'Authorization' => 'token ' . $github_token ] : [];
+		$headers      = $gitlab_token && strpos( $package_name, '://gitlab.com/' ) !== false ? [ 'PRIVATE-TOKEN' => $gitlab_token ] : [];
+		$response     = Utils\http_request( 'GET', $url, null /*data*/, $headers, $options );
+		if ( 20 === (int) substr( $response->status_code, 0, 2 ) ) {
+			return $url;
+		}
+
 		return false;
 	}
 

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -1175,7 +1175,7 @@ class Package_Command extends WP_CLI_Command {
 		if ( $url && ( strpos( $url, '://gitlab.com/' ) !== false ) || ( strpos( $url, 'git@gitlab.com:' ) !== false ) ) {
 			$matches = [];
 			preg_match( '#gitlab.com[:/](.*?)\.git#', $url, $matches );
-			return $this->check_gitlab_package_name( $matches[1] , $version, $insecure );
+			return $this->check_gitlab_package_name( $matches[1], $version, $insecure );
 		}
 
 		return $this->check_github_package_name( $package_name, $version, $insecure );
@@ -1190,21 +1190,21 @@ class Package_Command extends WP_CLI_Command {
 	 *                             to false.
 	 */
 	private function check_gitlab_package_name( $project_name, $version = '', $insecure = false ) {
+		$options = [ 'insecure' => $insecure ];
 		// Generate raw git URL of composer.json file.
 		$raw_content_public_url  = 'https://gitlab.com/' . $project_name . '/-/raw/' . $this->get_raw_git_version( $version ) . '/composer.json';
 		$raw_content_private_url = 'https://gitlab.com/api/v4/projects/' . rawurlencode( $project_name ) . '/repository/files/composer.json/raw?ref=' . $this->get_raw_git_version( $version );
 
 		$matches = [];
 		preg_match( '#([^:\/]+\/[^\/]+$)#', $project_name, $matches );
-		$default_package_name = $package_name = $matches[1];
-		$options = [ 'insecure' => $insecure ];
+		$package_name = $matches[1];
 
 		$gitlab_token = getenv( 'GITLAB_TOKEN' ); // Use GITLAB_TOKEN if available to avoid authorization failures or rate-limiting.
 		$response     = Utils\http_request( 'GET', $raw_content_public_url, null /*data*/, [], $options );
 		if ( ! $gitlab_token && ( $response->status_code < 200 || $response->status_code >= 300 ) ) {
 			// Could not get composer.json. Possibly private so warn and return best guess from input (always xxx/xxx).
-			WP_CLI::warning( sprintf( "Couldn't download composer.json file from '%s' (HTTP code %d). Presuming package name is '%s'.", $raw_content_public_url, $response->status_code, $default_package_name ) );
-			return $default_package_name;
+			WP_CLI::warning( sprintf( "Couldn't download composer.json file from '%s' (HTTP code %d). Presuming package name is '%s'.", $raw_content_public_url, $response->status_code, $package_name ) );
+			return $package_name;
 		}
 
 		if ( strpos( $response->headers['content-type'], 'text/html' ) === 0 ) {
@@ -1213,8 +1213,8 @@ class Package_Command extends WP_CLI_Command {
 
 			if ( $response->status_code < 200 || $response->status_code >= 300 ) {
 				// Could not get composer.json. Possibly private so warn and return best guess from input (always xxx/xxx).
-				WP_CLI::warning( sprintf( "Couldn't download composer.json file from '%s' (HTTP code %d). Presuming package name is '%s'.", $raw_content_private_url, $response->status_code, $default_package_name ) );
-				return $default_package_name;
+				WP_CLI::warning( sprintf( "Couldn't download composer.json file from '%s' (HTTP code %d). Presuming package name is '%s'.", $raw_content_private_url, $response->status_code, $package_name ) );
+				return $package_name;
 			}
 		}
 
@@ -1231,8 +1231,8 @@ class Package_Command extends WP_CLI_Command {
 		$package_name_on_repo = $composer_content_as_array['name'];
 
 		// If package name and repository name are not identical, then fix it.
-		if ( $default_package_name !== $package_name_on_repo ) {
-			WP_CLI::warning( sprintf( "Package name mismatch...Updating from git name '%s' to composer.json name '%s'.", $default_package_name, $package_name_on_repo ) );
+		if ( $package_name !== $package_name_on_repo ) {
+			WP_CLI::warning( sprintf( "Package name mismatch...Updating from git name '%s' to composer.json name '%s'.", $package_name, $package_name_on_repo ) );
 			$package_name = $package_name_on_repo;
 		}
 		return $package_name;

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -244,8 +244,8 @@ class Package_Command extends WP_CLI_Command {
 			// Download the remote ZIP file to a temp directory
 			$temp = false;
 			if ( false !== strpos( $package_name, '://' ) ) {
-				$temp     = Utils\get_temp_dir() . uniqid( 'wp-cli-package_', true /*more_entropy*/ ) . '.zip';
-				$options  = [
+				$temp         = Utils\get_temp_dir() . uniqid( 'wp-cli-package_', true /*more_entropy*/ ) . '.zip';
+				$options      = [
 					'timeout'  => 600,
 					'filename' => $temp,
 					'insecure' => $insecure,


### PR DESCRIPTION
- When retrieving a ZIP from a private repository, use authentication, if provided
- Fix the GitLab failover behavior (used to bail-out on private GitLab repositories without trying to use a token if one was provided)