### PR TITLE
Fix failing package-command tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,3 +12,5 @@ on:
 jobs:
   test:
     uses: wp-cli/.github/.github/workflows/reusable-testing.yml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -66,7 +66,7 @@ Feature: Install WP-CLI packages
       Version C.
       """
 
-  @require-php-5.6
+  @require-php-5.6 @test
   Scenario: Install a package with a dependency
     Given an empty directory
 


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/5720