### PR TITLE
Mark the test with `yoast/wp-cli-faker` as `@broken`

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -66,7 +66,7 @@ Feature: Install WP-CLI packages
       Version C.
       """
 
-  @require-php-5.6
+  @require-php-5.6 @broken
   Scenario: Install a package with a dependency
     Given an empty directory
 


### PR DESCRIPTION
It randomly fails tests a lot:

<img width="1423" alt="image" src="https://user-images.githubusercontent.com/36432/219740998-8413e1a7-b81d-4f2d-b52c-613e327ffcfd.png">
