### PR TITLE
Document support for GitHub token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ reference breaks.
 When installing a .zip file, WP-CLI extracts the package to
 `~/.wp-cli/packages/local/<package-name>`.
 
+If Github token authorization is required, a GitHub Personal Access Token
+(https://github.com/settings/tokens) can be used. The following command
+will add a GitHub Personal Access Token to Composer's global configuration:
+composer config -g github-oauth.github.com <GITHUB_TOKEN>
+Once this has been added, the value used for <GITHUB_TOKEN> will be used
+for future authorization requests.
+
 **OPTIONS**
 
 	<name|git|path|zip>

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -194,7 +194,7 @@ class Package_Command extends WP_CLI_Command {
 	 * composer config -g github-oauth.github.com <GITHUB_TOKEN>
 	 * Once this has been added, the value used for <GITHUB_TOKEN> will be used
 	 * for future authorization requests.
-	 * 
+	 *
 	 * ## OPTIONS
 	 *
 	 * <name|git|path|zip>

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -192,7 +192,7 @@ class Package_Command extends WP_CLI_Command {
 	 * (https://github.com/settings/tokens) can be used. The following command 
 	 * will add a Github Personal Access Token to Composer's global configuration:
 	 * composer config -g github-oauth.github.com <GITHUB_TOKEN>
-     * Once this has been added, the value used for <GITHUB_TOKEN> will be used 
+	 * Once this has been added, the value used for <GITHUB_TOKEN> will be used 
 	 * for future authorization requests.
 	 * 
 	 * ## OPTIONS

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -188,11 +188,11 @@ class Package_Command extends WP_CLI_Command {
 	 * When installing a .zip file, WP-CLI extracts the package to
 	 * `~/.wp-cli/packages/local/<package-name>`.
 	 *
-	 * If Github token authorization is required, a GitHub Personal Access Token 
-	 * (https://github.com/settings/tokens) can be used. The following command 
+	 * If Github token authorization is required, a GitHub Personal Access Token
+	 * (https://github.com/settings/tokens) can be used. The following command
 	 * will add a GitHub Personal Access Token to Composer's global configuration:
 	 * composer config -g github-oauth.github.com <GITHUB_TOKEN>
-	 * Once this has been added, the value used for <GITHUB_TOKEN> will be used 
+	 * Once this has been added, the value used for <GITHUB_TOKEN> will be used
 	 * for future authorization requests.
 	 * 
 	 * ## OPTIONS

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -190,7 +190,7 @@ class Package_Command extends WP_CLI_Command {
 	 *
 	 * If Github token authorization is required, a GitHub Personal Access Token 
 	 * (https://github.com/settings/tokens) can be used. The following command 
-	 * will add a Github Personal Access Token to Composer's global configuration:
+	 * will add a GitHub Personal Access Token to Composer's global configuration:
 	 * composer config -g github-oauth.github.com <GITHUB_TOKEN>
 	 * Once this has been added, the value used for <GITHUB_TOKEN> will be used 
 	 * for future authorization requests.

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -188,7 +188,7 @@ class Package_Command extends WP_CLI_Command {
 	 * When installing a .zip file, WP-CLI extracts the package to
 	 * `~/.wp-cli/packages/local/<package-name>`.
 	 *
-	 * If Github token authorization is required, a Github Personal Access Token 
+	 * If Github token authorization is required, a GitHub Personal Access Token 
 	 * (https://github.com/settings/tokens) can be used. The following command 
 	 * will add a Github Personal Access Token to Composer's global configuration:
 	 * composer config -g github-oauth.github.com <GITHUB_TOKEN>

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -188,6 +188,13 @@ class Package_Command extends WP_CLI_Command {
 	 * When installing a .zip file, WP-CLI extracts the package to
 	 * `~/.wp-cli/packages/local/<package-name>`.
 	 *
+	 * If Github token authorization is required, a Github Personal Access Token 
+	 * (https://github.com/settings/tokens) can be used. The following command 
+	 * will add a Github Personal Access Token to Composer's global configuration:
+	 * composer config -g github-oauth.github.com <GITHUB_TOKEN>
+     * Once this has been added, the value used for <GITHUB_TOKEN> will be used 
+	 * for future authorization requests.
+	 * 
 	 * ## OPTIONS
 	 *
 	 * <name|git|path|zip>


### PR DESCRIPTION
Fixes #84 

I've added some documentation on how <githug_token> is used if it is present for token authentication. As I don't have a private package to work with this needs to be tested to make sure that the github_token functionality outlined in the code is indeed working.

Related https://github.com/wp-cli/wp-cli/issues/5832