### PR TITLE
Fix failing test

### DIFF
--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -1063,7 +1063,7 @@ Feature: Install WP-CLI packages
 
     When I try `wp package install https://example.com/non-existent-zip-asdfasdf.zip`
     Then the return code should be 1
-    And STDERR should cintain:
+    And STDERR should contain:
       """
       Error: Couldn't download package from 'https://example.com/non-existent-zip-asdfasdf.zip'
       """

--- a/features/package-install.feature
+++ b/features/package-install.feature
@@ -1063,9 +1063,9 @@ Feature: Install WP-CLI packages
 
     When I try `wp package install https://example.com/non-existent-zip-asdfasdf.zip`
     Then the return code should be 1
-    And STDERR should be:
+    And STDERR should cintain:
       """
-      Error: Couldn't download package from 'https://example.com/non-existent-zip-asdfasdf.zip' (HTTP code 404).
+      Error: Couldn't download package from 'https://example.com/non-existent-zip-asdfasdf.zip'
       """
     And STDOUT should be empty
 

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -1166,7 +1166,7 @@ class Package_Command extends WP_CLI_Command {
 	 *                             to false.
 	 */
 	private function check_git_package_name( $package_name, $url = '', $version = '', $insecure = false ) {
-		if ( $url && ( strpos( $url, '://gitlab.com/' ) !== false ) || ( strpos( $url, 'git@gitlab.com:' ) !== false ) ) {
+		if ( $url && ( ( strpos( $url, '://gitlab.com/' ) !== false ) || ( strpos( $url, 'git@gitlab.com:' ) !== false ) ) ) {
 			$matches = [];
 			preg_match( '#gitlab.com[:/](.*?)\.git#', $url, $matches );
 			return $this->check_gitlab_package_name( $matches[1], $version, $insecure );

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -1178,7 +1178,7 @@ class Package_Command extends WP_CLI_Command {
 	/**
 	 * Checks that `$package_name` matches the name in composer.json at GitLab.com, and return corrected value if not.
 	 *
-	 * @param string $package_name Package name to check.
+	 * @param string $project_name Package name to check.
 	 * @param string $version      Optional. Package version. Defaults to empty string.
 	 * @param bool   $insecure     Optional. Whether to insecurely retry downloads that failed TLS handshake. Defaults
 	 *                             to false.


### PR DESCRIPTION
example.com is now returning 500 errors instead of 404s.

This makes the assertion less strict in case it changes back.

Tests should be passing again.

Workflows in this repo were disabled, only noticed it here: https://github.com/wp-cli/automated-tests/actions/runs/8563026050/job/23467388987#step:14:195