### PR TITLE
Update docs and examples for package commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,19 @@ WP-CLI packages are community-maintained projects built on WP-CLI. They can
 contain WP-CLI commands, but they can also just extend WP-CLI in some way.
 
 Learn how to create your own command from the
-[Commands Cookbook](https://make.wordpress.org/cli/handbook/commands-cookbook/)
+[Commands Cookbook](https://make.wordpress.org/cli/handbook/guides/commands-cookbook/)
 
 **EXAMPLES**
 
-    # List installed packages
+    # List installed packages.
     $ wp package list
-    +-----------------------+------------------------------------------+---------+----------+
-    | name                  | description                              | authors | version  |
-    +-----------------------+------------------------------------------+---------+----------+
-    | wp-cli/server-command | Start a development server for WordPress |         | dev-main |
-    +-----------------------+------------------------------------------+---------+----------+
+    +-----------------------+------------------+----------+-----------+----------------+
+    | name                  | authors          | version  | update    | update_version |
+    +-----------------------+------------------+----------+-----------+----------------+
+    | wp-cli/server-command | Daniel Bachhuber | dev-main | available | 2.x-dev        |
+    +-----------------------+------------------+----------+-----------+----------------+
 
-    # Install the latest development version of the package
+    # Install the latest development version of the package.
     $ wp package install wp-cli/server-command
     Installing package wp-cli/server-command (dev-main)
     Updating /home/person/.wp-cli/packages/composer.json to require the package...
@@ -53,11 +53,11 @@ Learn how to create your own command from the
     ---
     Success: Package installed.
 
-    # Uninstall package
+    # Uninstall package.
     $ wp package uninstall wp-cli/server-command
-    Removing require statement from /home/person/.wp-cli/packages/composer.json
-    Deleting package directory /home/person/.wp-cli/packages/vendor/wp-cli/server-command
-    Regenerating Composer autoload.
+    Removing require statement for package 'wp-cli/server-command' from /home/person/.wp-cli/packages/composer.json
+    Removing repository details from /home/person/.wp-cli/packages/composer.json
+    Removing package directories and regenerating autoloader...
     Success: Uninstalled package.
 
 
@@ -225,12 +225,13 @@ These fields are optionally available:
 
 **EXAMPLES**
 
+    # List installed packages.
     $ wp package list
-    +-----------------------+------------------------------------------+---------+----------+
-    | name                  | description                              | authors | version  |
-    +-----------------------+------------------------------------------+---------+----------+
-    | wp-cli/server-command | Start a development server for WordPress |         | dev-main |
-    +-----------------------+------------------------------------------+---------+----------+
+    +-----------------------+------------------+----------+-----------+----------------+
+    | name                  | authors          | version  | update    | update_version |
+    +-----------------------+------------------+----------+-----------+----------------+
+    | wp-cli/server-command | Daniel Bachhuber | dev-main | available | 2.x-dev        |
+    +-----------------------+------------------+----------+-----------+----------------+
 
 
 
@@ -278,10 +279,11 @@ wp package uninstall <name> [--insecure]
 
 **EXAMPLES**
 
+    # Uninstall package.
     $ wp package uninstall wp-cli/server-command
-    Removing require statement from /home/person/.wp-cli/packages/composer.json
-    Deleting package directory /home/person/.wp-cli/packages/vendor/wp-cli/server-command
-    Regenerating Composer autoload.
+    Removing require statement for package 'wp-cli/server-command' from /home/person/.wp-cli/packages/composer.json
+    Removing repository details from /home/person/.wp-cli/packages/composer.json
+    Removing package directories and regenerating autoloader...
     Success: Uninstalled package.
 
 ## Installing

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -29,19 +29,19 @@ use WP_CLI\RequestsLibrary;
  * contain WP-CLI commands, but they can also just extend WP-CLI in some way.
  *
  * Learn how to create your own command from the
- * [Commands Cookbook](https://make.wordpress.org/cli/handbook/commands-cookbook/)
+ * [Commands Cookbook](https://make.wordpress.org/cli/handbook/guides/commands-cookbook/)
  *
  * ## EXAMPLES
  *
- *     # List installed packages
+ *     # List installed packages.
  *     $ wp package list
- *     +-----------------------+------------------------------------------+---------+----------+
- *     | name                  | description                              | authors | version  |
- *     +-----------------------+------------------------------------------+---------+----------+
- *     | wp-cli/server-command | Start a development server for WordPress |         | dev-main |
- *     +-----------------------+------------------------------------------+---------+----------+
+ *     +-----------------------+------------------+----------+-----------+----------------+
+ *     | name                  | authors          | version  | update    | update_version |
+ *     +-----------------------+------------------+----------+-----------+----------------+
+ *     | wp-cli/server-command | Daniel Bachhuber | dev-main | available | 2.x-dev        |
+ *     +-----------------------+------------------+----------+-----------+----------------+
  *
- *     # Install the latest development version of the package
+ *     # Install the latest development version of the package.
  *     $ wp package install wp-cli/server-command
  *     Installing package wp-cli/server-command (dev-main)
  *     Updating /home/person/.wp-cli/packages/composer.json to require the package...
@@ -59,11 +59,11 @@ use WP_CLI\RequestsLibrary;
  *     ---
  *     Success: Package installed.
  *
- *     # Uninstall package
+ *     # Uninstall package.
  *     $ wp package uninstall wp-cli/server-command
- *     Removing require statement from /home/person/.wp-cli/packages/composer.json
- *     Deleting package directory /home/person/.wp-cli/packages/vendor/wp-cli/server-command
- *     Regenerating Composer autoload.
+ *     Removing require statement for package 'wp-cli/server-command' from /home/person/.wp-cli/packages/composer.json
+ *     Removing repository details from /home/person/.wp-cli/packages/composer.json
+ *     Removing package directories and regenerating autoloader...
  *     Success: Uninstalled package.
  *
  * @package WP-CLI
@@ -450,12 +450,13 @@ class Package_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
+	 *     # List installed packages.
 	 *     $ wp package list
-	 *     +-----------------------+------------------------------------------+---------+----------+
-	 *     | name                  | description                              | authors | version  |
-	 *     +-----------------------+------------------------------------------+---------+----------+
-	 *     | wp-cli/server-command | Start a development server for WordPress |         | dev-main |
-	 *     +-----------------------+------------------------------------------+---------+----------+
+	 *     +-----------------------+------------------+----------+-----------+----------------+
+	 *     | name                  | authors          | version  | update    | update_version |
+	 *     +-----------------------+------------------+----------+-----------+----------------+
+	 *     | wp-cli/server-command | Daniel Bachhuber | dev-main | available | 2.x-dev        |
+	 *     +-----------------------+------------------+----------+-----------+----------------+
 	 *
 	 * @subcommand list
 	 */
@@ -476,11 +477,15 @@ class Package_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     # Get package path
+	 *     # Get package path.
 	 *     $ wp package path
 	 *     /home/person/.wp-cli/packages/
 	 *
-	 *     # Change directory to package path
+	 *     # Get path to an installed package.
+	 *     $ wp package path wp-cli/server-command
+	 *     /home/person/.wp-cli/packages/vendor/wp-cli/server-command
+	 *
+	 *     # Change directory to package path.
 	 *     $ cd $(wp package path) && pwd
 	 *     /home/vagrant/.wp-cli/packages
 	 */
@@ -559,10 +564,11 @@ class Package_Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
+	 *     # Uninstall package.
 	 *     $ wp package uninstall wp-cli/server-command
-	 *     Removing require statement from /home/person/.wp-cli/packages/composer.json
-	 *     Deleting package directory /home/person/.wp-cli/packages/vendor/wp-cli/server-command
-	 *     Regenerating Composer autoload.
+	 *     Removing require statement for package 'wp-cli/server-command' from /home/person/.wp-cli/packages/composer.json
+	 *     Removing repository details from /home/person/.wp-cli/packages/composer.json
+	 *     Removing package directories and regenerating autoloader...
 	 *     Success: Uninstalled package.
 	 */
 	public function uninstall( $args, $assoc_args ) {


### PR DESCRIPTION
* Fix cookbook URL
* Correct example for `package uninstall` and `package list` commands
* Add new example for package path command