### PR TITLE
Require `wp-cli/wp-cli` v2.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
   "require": {
     "ext-json": "*",
     "composer/composer": "^1.10.23 || ^2.2.17",
-    "wp-cli/wp-cli": "^2.8"
+    "wp-cli/wp-cli": "^2.12"
   },
   "require-dev": {
     "wp-cli/scaffold-command": "^1 || ^2",


### PR DESCRIPTION
For improved PHP 8.4 compatibility.