### PR TITLE
Drop support for composer v1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "ext-json": "*",
-    "composer/composer": "^1.10.23 || ^2.2.17",
+    "composer/composer": "^2.2.25",
     "wp-cli/wp-cli": "^2.12"
   },
   "require-dev": {


### PR DESCRIPTION
* Packagist is dropping support for composer v1
* composer v1 uses an outdated version of `symfony/process`, causing installs to fail on PHP 5.6

`composer/composer` 2.2 still supports PHP 5.3+ so that's no issue.

In the future we can bump the minimum requirement to v2.8+ (requires PHP 7.2+)

Fixes #194

See https://github.com/wp-cli/wp-cli/issues/6018