### PR TITLE
Raise Composer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
   ],
   "require": {
     "ext-json": "*",
-    "composer/composer": "^2.9.5",
+    "composer/composer": "^2.10.2",
     "wp-cli/wp-cli": "^2.13"
   },
   "require-dev": {


### PR DESCRIPTION
`composer require composer/composer:"^2.10.2"`

Fix #239 

Upgrading from Composer 2.9.5. Lots of changes.

https://github.com/composer/composer/releases?page=1#release-2.10.2

* [2.9.6](https://github.com/composer/composer/releases/tag/2.9.6)
* [2.9.7](https://github.com/composer/composer/releases/tag/2.9.7)
* [2.9.8](https://github.com/composer/composer/releases/tag/2.9.8)
* [2.10.0](https://github.com/composer/composer/releases/tag/2.10.0)
* [2.10.1](https://github.com/composer/composer/releases/tag/2.10.1)
* [2.10.2](https://github.com/composer/composer/releases/tag/2.10.2)

An unrelated security fix in the latest Composer release caused me a problem today so I can't confidently say this update won't have knock-on effects, but I don't think we can ignore it regardless.

Previously:

package-command | PR | Commit | Change
-|-|-|-
[v2.5.0](https://github.com/wp-cli/package-command/releases/tag/v2.5.0) | Fix compatibility with newer Composer versions #183 | 8e8d112c0b42c75e7fe57d10492502fba1f9910e|  `^1.10.23 \|\| ~2.2.17` ->`^1.10.23 \|\| ^2.2.17`
[v2.6.0](https://github.com/wp-cli/package-command/releases/tag/v2.6.0) | Drop support for composer v1 #196 | 0de8814060c555d15aa782bff56385f4e8464f63 |  `^1.10.23 \|\| ^2.2.17` -> `^2.2.25`
[v2.7.0](https://github.com/wp-cli/package-command/releases/tag/v2.7.0) | Fix some newly reported PHPStan issues #220 |  a7e0431cbe77a97568fdd30bdc2e7cf84b099cc6 | `^2.2.25` -> `^2.9.5`
