### PR TITLE
Restrict packages directory permissions to 0700

### DIFF
--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -1283,7 +1283,7 @@ class Package_Command extends WP_CLI_Command {
 
 		$composer_dir = pathinfo( $composer_path, PATHINFO_DIRNAME );
 		if ( ! is_dir( $composer_dir ) ) {
-			if ( ! @mkdir( $composer_dir, 0777, true ) ) { // @codingStandardsIgnoreLine
+			if ( ! @mkdir( $composer_dir, 0700, true ) ) { // @codingStandardsIgnoreLine
 				$error = error_get_last();
 				WP_CLI::error( sprintf( "Composer directory '%s' for packages couldn't be created: %s", $composer_dir, $error['message'] ) );
 			}

--- a/tests/phpunit/ComposerJsonTest.php
+++ b/tests/phpunit/ComposerJsonTest.php
@@ -87,6 +87,9 @@ class ComposerJsonTest extends TestCase {
 		$actual   = $create_default_composer_json->invoke( $package, $expected );
 		$this->assertSame( $this->mac_safe_path( realpath( $expected ) ?: $expected ), $this->mac_safe_path( realpath( $actual ) ?: $actual ) );
 		$this->assertTrue( false !== strpos( file_get_contents( $actual ), 'wp-cli/wp-cli' ) );
+		if ( ! Utils\is_windows() ) {
+			$this->assertSame( '0700', substr( sprintf( '%o', fileperms( dirname( $actual ) ) ), -4 ) );
+		}
 		unlink( $actual );
 		rmdir( dirname( $actual ) );
 	}


### PR DESCRIPTION
Restricts directory permissions for `~/.wp-cli/packages` (or `WP_CLI_PACKAGES_DIR`) to `0700` upon creation in `Package_Command::create_default_composer_json()`.

Previously, `0777` was passed to `mkdir()`, which masked permissions using the active umask (e.g. `002` or `000`). This left the package directory group- or world-writable on environments with permissive umasks, exposing users to potential local code execution via the package autoloader.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for generated Composer package directories by restricting permissions to the owner.
* **Tests**
  * Added coverage to verify the updated directory permissions on supported systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->