### PR TITLE
Use 0755 instead of 0700 for the packages directory

### DIFF
--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -1283,10 +1283,6 @@ class Package_Command extends WP_CLI_Command {
 
 		$composer_dir = pathinfo( $composer_path, PATHINFO_DIRNAME );
 		if ( ! is_dir( $composer_dir ) ) {
-			// 0755 rather than 0700: the risk being guarded against is another local user
-			// *writing* into the packages directory, whose `vendor/autoload.php` is required on
-			// every WP-CLI run. Read access was never the problem, and revoking it breaks setups
-			// that point `WP_CLI_PACKAGES_DIR` at a location shared between users.
 			if ( ! @mkdir( $composer_dir, 0755, true ) ) { // @codingStandardsIgnoreLine
 				$error = error_get_last();
 				WP_CLI::error( sprintf( "Composer directory '%s' for packages couldn't be created: %s", $composer_dir, $error['message'] ) );

--- a/src/Package_Command.php
+++ b/src/Package_Command.php
@@ -1283,7 +1283,11 @@ class Package_Command extends WP_CLI_Command {
 
 		$composer_dir = pathinfo( $composer_path, PATHINFO_DIRNAME );
 		if ( ! is_dir( $composer_dir ) ) {
-			if ( ! @mkdir( $composer_dir, 0700, true ) ) { // @codingStandardsIgnoreLine
+			// 0755 rather than 0700: the risk being guarded against is another local user
+			// *writing* into the packages directory, whose `vendor/autoload.php` is required on
+			// every WP-CLI run. Read access was never the problem, and revoking it breaks setups
+			// that point `WP_CLI_PACKAGES_DIR` at a location shared between users.
+			if ( ! @mkdir( $composer_dir, 0755, true ) ) { // @codingStandardsIgnoreLine
 				$error = error_get_last();
 				WP_CLI::error( sprintf( "Composer directory '%s' for packages couldn't be created: %s", $composer_dir, $error['message'] ) );
 			}

--- a/tests/phpunit/ComposerJsonTest.php
+++ b/tests/phpunit/ComposerJsonTest.php
@@ -88,7 +88,15 @@ class ComposerJsonTest extends TestCase {
 		$this->assertSame( $this->mac_safe_path( realpath( $expected ) ?: $expected ), $this->mac_safe_path( realpath( $actual ) ?: $actual ) );
 		$this->assertTrue( false !== strpos( file_get_contents( $actual ), 'wp-cli/wp-cli' ) );
 		if ( ! Utils\is_windows() ) {
-			$this->assertSame( '0700', substr( sprintf( '%o', fileperms( dirname( $actual ) ) ), -4 ) );
+			// The invariant that matters is that no other local user can write into the packages
+			// directory, whose `vendor/autoload.php` is required on every WP-CLI run. The exact
+			// mode depends on the umask, so assert the write bits rather than the literal mode.
+			$perms = fileperms( dirname( $actual ) ) & 0777;
+			$this->assertSame(
+				0,
+				$perms & 0022,
+				sprintf( 'Packages directory must not be group- or world-writable, got %o.', $perms )
+			);
 		}
 		unlink( $actual );
 		rmdir( dirname( $actual ) );


### PR DESCRIPTION
Follow-up to #243, which set the packages directory to `0700`.

## The problem

`0700` breaks installations that point `WP_CLI_PACKAGES_DIR` at a location shared between users — e.g. a host setting `WP_CLI_PACKAGES_DIR: /opt/wp-cli/packages` in `/etc/wp-cli/config.yml`. Whichever user first runs `wp package install` creates and owns the directory, and every other user then silently loses their packages, because `IncludePackageAutoloader` only checks `is_readable()`:

```php
if ( is_readable( $autoloader_path ) ) { return [ $autoloader_path ]; }
return false;   // → handle_failure() → WP_CLI::debug( 'No package autoload found to load.' )
```

No error, no warning — the packages just stop existing unless you run `--debug`.

## Why 0755 is enough

The risk #243 guards against is another local user **writing** into the packages directory, whose `vendor/autoload.php` is required on every single WP-CLI run. Read access was never part of that — these are downloaded public packages, not secrets. `0755` removes group and world write outright, and a umask can only clear further bits, so the result is never group- or world-writable:

| umask | old `mkdir(0777)` | new `mkdir(0755)` |
|---|---|---|
| 022 (default) | 0755 | 0755 |
| 002 (shared group) | **0775** | 0755 |
| 000 (common in containers) | **0777** | 0755 |
| 077 | 0700 | 0700 |

The two rows in bold are the configurations that made this exploitable in the first place, and `0755` closes both.

Note this only affects directories WP-CLI creates — the `is_dir()` guard leaves a pre-provisioned directory untouched, so an admin who sets up a shared packages directory with a group and the setgid bit keeps full control either way.

## Test change

The unit test asserted the literal string `0700`, which is umask-dependent. It now asserts that the group and other write bits are unset, which is the invariant that actually matters and holds under any umask.

## Testing

`php -l` passes on both files. I could not run PHPUnit in my environment — `composer install` cannot authenticate to github.com for the dev dependencies — so CI is the real check here. I did verify the permission behaviour and both assertion styles directly across the four umasks in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qPfx7yCg9xCTys3XXXRkU

---
_Generated by [Claude Code](https://claude.ai/code/session_014qPfx7yCg9xCTys3XXXRkU)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access to the default packages directory in shared-user environments.
  * Maintained protection against write access from group and other users.

* **Tests**
  * Updated permission checks to accommodate system umask differences while ensuring unsafe write permissions remain disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->